### PR TITLE
为了兼容 ROS 写一个 spec

### DIFF
--- a/docs/specs/2018-04-03.md
+++ b/docs/specs/2018-04-03.md
@@ -1,0 +1,329 @@
+# Fun with Serverless（fun）
+
+#### Version 2018-04-03
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](http://www.ietf.org/rfc/rfc2119.txt).
+
+The Fun with Serverless（fun） is licensed under The [MIT License](https://opensource.org/licenses/MIT).
+
+## Introduction
+
+Fun is a model used to define serverless applications on Aliyun.
+
+Serverless applications are applications composed of functions triggered by events. A typical serverless application consists of one or more Aliyun Function Compute triggered by events such as object uploads to [Aliyun OSS](https://www.alibabacloud.com/product/oss), performs data operations on [Aliyun OTS](https://www.alibabacloud.com/product/table-store), and API actions. Those functions can stand alone or leverage other resources such as Aliyun OTS tables or OSS buckets. The most basic serverless application is simply a function.
+
+Fun is designed to be compatible with Aliyun ROS. Although so far ROS not support Function Compute. However, Fun as the subset of the ROS is our goal.
+
+## Specification
+
+### Format
+
+The files describing a serverless application in accordance with Aliyun Fun are [JSON](http://www.json.org/) or [YAML](http://yaml.org/spec/1.1/) formatted text files. These files are compatible with [ROS templates](https://www.alibabacloud.com/help/doc-detail/28852.htm).
+
+Aliyun Fun introduces several new resources and property types that can be embedded into the [Resources](https://www.alibabacloud.com/help/doc-detail/28863.htm) section of the template. The templates may include all other template sections and use [ROS build-in functions](https://www.alibabacloud.com/help/doc-detail/28865.htm) to access properties available only at runtime.
+
+In order to include objects defined by Aliyun Fun within a ROS template, the template must include a `Transform` section in the document root with a value of `Aliyun::Serverless-2018-04-03`.
+
+- [Globals Section](#globals-section)
+- [Resource types](#resource-types)
+- [Event source types](#event-source-types)
+- [Property types](#property-types)
+
+### Example: Aliyun Fun template
+
+```yaml
+ROSTemplateFormatVersion: '2015-09-01'
+Transform: 'Aliyun::Serverless-2018-04-03'
+Resources:
+  MyService:
+    Type: 'Aliyun::Serverless::Service'
+    Policies:
+      - AliyunFCExecute # Managed Policy
+      - Version: '2012-10-17' # Policy Document
+        Statement:
+          - Effect: Allow
+            Action:
+              - oss:GetObject
+              - oss:GetObjectACL
+            Resource: 'acs:oss:::my-bucket/*'
+    MyFunction:
+      Type: 'Aliyun::Serverless::Function'
+      Properties:
+        Handler: index.handler
+        Runtime: nodejs6.10
+        CodeUri: 'oss://my-bucket/function.zip'
+```
+
+All property names in Aliyun Fun are **case sensitive**.
+
+### Globals Section
+
+Globals is a section in your Fun template to define properties common to all your Serverless Function and APIs. All the `Aliyun::Serverless::Function` and
+`Aliyun::Serverless::Api` resources will inherit the properties defined here.
+
+Example:
+
+```
+Globals:
+  Service:
+    Function:
+      Runtime: nodejs6.10
+      Timeout: 180
+      Handler: index.handler
+  Api:
+    EndpointConfiguration: REGIONAL
+    Cors: "'www.example.com'"
+```
+
+### Resource types
+
+- [Aliyun::Serverless::Service](#aliyunserverlessservice)
+  - [Aliyun::Serverless::Function](#aliyunserverlessfunction)
+- [Aliyun::Serverless::Api](#aliyunserverlessapi)
+
+#### Aliyun::Serverless::Service
+
+Creates a FC service that is a function group , bind common propertis , like [RAM](https://www.alibabacloud.com/product/ram) execution role.
+
+##### Properties
+
+Property Name | Type | Description
+---|:---:|---
+ServiceName | `string` | A name for the function. If you don't specify a name, a unique name will be generated for you. [More Info](https://www.alibabacloud.com/help/doc-detail/52077.htm)
+Role | `string` | ARN of an RAM role to use as this function's execution role. If omitted, a default role is created for this function.
+Policies | `string` <span>&#124;</span> List of `string` <span>&#124;</span> [RAM policy document object](https://www.alibabacloud.com/help/doc-detail/28663.htm) <span>&#124;</span> List of [RAM policy document object](https://www.alibabacloud.com/help/doc-detail/28663.htm) | Names of Aliyun managed RAM policies or RAM policy documents that this function needs, which should be appended to the default role for this function. If the Role property is set, this property has no meaning.
+Log | `string` | ARN of SLS
+
+#### Aliyun::Serverless::Function
+
+Creates a FC function and event source mappings which trigger the function. Function is child node of a service.
+
+##### Properties
+
+Property Name | Type | Description
+---|:---:|---
+Handler | `string` | **Required.** Function within your code that is called to begin execution.
+Runtime | `string` | **Required.** The runtime environment.
+CodeUri | `string` <span>&#124;</span> [OSS Location Object](#oss-location-object) | **Required.** OSS Uri or location to the function code. The OSS object this Uri references MUST be a FC deployment package.
+FunctionName | `string` | A name for the function. If you don't specify a name, a unique name will be generated for you. [More Info](https://www.alibabacloud.com/help/doc-detail/52077.htm)
+Description | `string` | Description of the function.
+MemorySize | `integer` | Size of the memory allocated per invocation of the function in MB. Defaults to 128.
+Timeout | `integer` | Maximum time that the function can run before it is killed in seconds. Defaults to 3.
+Events | Map of `string` to [Event source object](#event-source-object) | A map (string to [Event source object](#event-source-object)) that defines the events that trigger this function. Keys are limited to alphanumeric characters.
+
+##### Return values
+
+###### Ref
+
+When the logical ID of this resource is provided to the [Ref](https://www.alibabacloud.com/help/doc-detail/28865.htm?spm=a3c0i.o28852en.b99.21.13b17874UM6SfP#Ref) build-in function, it returns the resource name of the underlying FC function.
+
+###### Fn::GetAtt
+
+When the logical ID of this resource is provided to the [Fn::GetAtt](https://www.alibabacloud.com/help/doc-detail/28865.htm?spm=a3c0i.o28852en.b99.21.13b17874UM6SfP#Fn::GetAtt) build-in function, it returns a value for a specified attribute of this type. This section lists the available attributes.
+
+Attribute Name | Description
+---|---
+Arn | The ARN of the FC function.
+
+This can be used with other build-in functions such as "Fn::GetAtt" or "Fn::Sub" or "Fn::Join" as well.
+
+###### Example: Aliyun::Serverless::Function
+
+```yaml
+Handler: index.js
+Runtime: nodejs6.10
+CodeUri: 'oss://my-code-bucket/my-function.zip'
+Description: Creates thumbnails of uploaded images
+MemorySize: 1024
+Timeout: 15
+Events:
+  PhotoUpload:
+    Type: OSS
+    Properties:
+      Bucket: my-photo-bucket
+```
+
+#### Aliyun::Serverless::Api
+
+Creates a collection of Aliyun API Gateway resources and methods that can be invoked through HTTPS endpoints.
+
+An `Aliyun::Serverless::Api` resource need not be explicitly added to a Aliyun Serverless Application Definition template. A resource of this type is implicitly created from the union of [Api](#api) events defined on `Aliyun::Serverless::Function` resources defined in the template that do not refer to an `Aliyun::Serverless::Api` resource. An `Aliyun::Serverless::Api` resource should be used to define and document the API using Swagger, which provides more ability to configure the underlying Aliyun API Gateway resources.
+
+##### Properties
+
+Property Name | Type | Description
+---|:---:|---
+Name | `string` | A name for the API Gateway RestApi resource.
+DefinitionUri | `string` <span>&#124;</span> [OSS Location Object](#oss-location-object) | OSS URI or location to the Swagger document describing the API. Either one of `DefinitionUri` or `DefinitionBody` must be specified.
+DefinitionBody | `JSON or YAML Object` | Swagger specification that describes your API. Either one of `DefinitionUri` or `DefinitionBody` must be specified.
+BinaryMediaTypes | List of `string` |  List of MIME types that your API could return. Use this to enable binary support for APIs. Use `~1` instead of `/` in the mime types .
+Cors | `string` or [Cors Configuration](#cors-configuration) | Enable CORS for all your APIs. Specify the domain to allow as a string or specify a dictionary with additional [Cors Configuration](#cors-configuration). NOTE: Cors requires Fun to modify your Swagger definition. Hence it works only inline swagger defined with `DefinitionBody`.
+
+##### Return values
+
+###### Ref
+
+When the logical ID of this resource is provided to the [Ref build-in function](https://www.alibabacloud.com/help/doc-detail/28865.htm?spm=a3c0i.o28852en.b99.21.13b17874UM6SfP#Ref), it returns the resource name of the underlying API Gateway RestApi.
+
+##### Example: Aliyun::Serverless::Api
+
+```yaml
+StageName: prod
+DefinitionUri: swagger.yml
+```
+
+### Event source types
+
+- [OSS](#oss)
+- [OTS](#ots)
+- [Api](#api)
+- [Datahub](#datahub)
+
+#### OSS
+
+The object describing an event source with type `OSS`.
+
+##### Properties
+
+Property Name | Type | Description
+---|:---:|---
+Bucket | `string` | **Required.** OSS bucket name.
+Events | `string` <span>&#124;</span> List of `string` | **Required.** See [Aliyun OSS supported event types](https://www.alibabacloud.com/help/doc-detail/53102.htm) for valid values.
+Filter | [OSS object filter](https://www.alibabacloud.com/help/doc-detail/53102.htm) | Rules to filter events on.
+
+##### Example: OSS event source object
+
+```yaml
+Type: OSS
+Properties:
+  Bucket: my-photo-bucket
+  Events: oss:ObjectCreated:*
+```
+
+#### OTS
+
+The object describing an event source with type `OTS`.
+
+##### Properties
+
+Property Name | Type | Description
+---|:---:|---
+Stream | `string` | **Required.** ARN of the OTS stream.
+
+##### Example: DynamoDB event source object
+
+```yaml
+Type: OTS
+Properties:
+  Stream: acs:ots:cn-hangzhou:123456789012:instance/test_instance/table/test_table
+```
+
+#### Api
+
+The object describing an event source with type `Api`.
+
+If an [Aliyun::Serverless::Api](#aliyun-serverless-api) resource is defined, the path and method values MUST correspond to an operation in the Swagger definition of the API. If no [Aliyun::Serverless::Api](#aliyun-serverless-api) is defined, the function input and output are a representation of the HTTP request and HTTP response. For example, using the JavaScript API, the status code and body of the response can be controlled by returning an object with the keys `statusCode` and `body`.
+
+##### Properties
+
+Property Name | Type | Description
+---|:---:|---
+Path | `string` | **Required.** Uri path for which this function is invoked. MUST start with `/`.
+Method | `string` | **Required.** HTTP method for which this function is invoked.
+RestApiId | `string` | Identifier of a RestApi resource which MUST contain an operation with the given path and method. Typically, this is set to [reference](https://www.alibabacloud.com/help/doc-detail/28865.htm?spm=a3c0i.o28852en.b99.21.13b17874UM6SfP#Ref) an `Aliyun::Serverless::Api` resource defined in this template. If not defined, a default `Aliyun::Serverless::Api` resource is created using a generated Swagger document contains a union of all paths and methods defined by `Api` events defined in this template that do not specify a RestApiId.
+
+##### Example: Api event source object
+
+```yaml
+Type: Api
+Properties:
+  Path: /photos
+  Method: post
+```
+
+#### Datahub
+
+The object describing an event source with type `Datahub`.
+
+##### Properties
+
+Property Name | Type | Description
+---|:---:|---
+Topic | `string` | **Required.** ARN of the Aliyun Datahub topic.
+StartingPosition | `string` | **Required.** One of `OLDEST` or `LATEST` or `SYSTEM_TIME`.
+StaringTime | `datetime` | Required if StartingPosition value is `SYSTEM_TIME`. The time format is `YYYY-MM-DD hh:mm`
+BatchSize | `integer` | Maximum number of stream records to process per function invocation.
+
+##### Example: Datahub event source object
+
+```yaml
+Type: Datahub
+Properties:
+  Topic: acs:dhs:cn-hangzhou:123456789012:projects/my-prj/topics/my-tpc
+  StartingPosition: TRIM_HORIZON
+  BatchSize: 10
+```
+
+### Property types
+
+- [Event source object](#event-source-object)
+
+#### Event source object
+
+The object describing the source of events which trigger the function.
+
+##### Properties
+
+Property Name | Type | Description
+---|:---:|---
+Type | `string` | **Required.** Event type. Event source types include '[OSS](#oss), '[Api](#api)', '[OTS](#ots)', '[Datahub](#datahub)'. For more information about all types, see [Event source types](#event-source-types).
+Properties | * | **Required.** Object describing properties of this event mapping. Must conform to the defined `Type`. For more information about all types, see [Event source types](#event-source-types).
+
+##### Example: Event source object
+
+```yaml
+Type: OSS
+Properties:
+  Bucket: my-photo-bucket
+```
+
+```yaml
+Type: Api
+```
+
+### Data Types
+
+#### OSS Location Object
+
+Specifies the location of an OSS object as a dictionary containing `Bucket`, `Key`, and optional `Version` properties.
+
+Example:
+```
+CodeUri:
+  Bucket: mybucket-name
+  Key: code.zip
+  Version: 121212
+```
+
+#### Cors Configuration
+
+Enable and configure CORS for the APIs. Enabling CORS will allow your API to be called from other domains. Assume your API is served from 'www.example.com' and you want to allow.
+
+```yaml
+
+Cors:
+  AllowMethods: Optional. String containing the HTTP methods to allow. 
+  # For example, "'GET,POST,DELETE'". If you omit this property, then SAM will automatically allow all the methods configured for each API. 
+  # Checkout [HTTP Spec](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Methods) more details on the value.
+
+  AllowHeaders: Optional. String of headers to allow. 
+  # For example, "'X-Forwarded-For'". Checkout [HTTP Spec](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers) for more details on the value
+
+  AllowOrigin: Required. String of origin to allow. 
+  # For example, "'www.example.com'". Checkout [HTTP Spec](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin) for more details on this value.
+
+  MaxAge: Optional. String containing the number of seconds to cache CORS Preflight request. 
+  # For example, "'600'" will cache request for 600 seconds. Checkout [HTTP Spec](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Max-Age) for more details on this value
+```
+
+> NOTE: HTTP spec requires the value of Allow properties to be a quoted string. So don't forget the additional quotes in the value. ie. "'www.example.com'" is correct whereas "www.example.com" is wrong

--- a/examples/datahub/template.yml
+++ b/examples/datahub/template.yml
@@ -1,0 +1,18 @@
+ROSTemplateFormatVersion: '2015-09-01'
+Transform: 'Aliyun::Serverless-2018-04-03'
+Resources:
+  MyService:
+    Type: 'Aliyun::Serverless::Service'
+    MyFunction:
+      Type: 'Aliyun::Serverless::Function'
+      Properties:
+        Handler: datahub.index
+        Runtime: nodejs6.10
+        CodeUri: './'
+      Events:
+        DhsTrigger:
+          Type: Datahub
+          Properties: 
+            Topic: acs:dhs:cn-hangzhou:123456789012:projects/my-prj/topics/my-tpc
+            StartingPosition: LATEST
+            BatchSize: 100

--- a/examples/helloworld/template.yml
+++ b/examples/helloworld/template.yml
@@ -1,0 +1,20 @@
+ROSTemplateFormatVersion: '2015-09-01'
+Transform: 'Aliyun::Serverless-2018-04-03'
+Resources:
+  fc:
+    Type: 'Aliyun::Serverless::Service'
+    Properties:
+      Description: 'fc test'
+    helloworld:
+      Type: 'Aliyun::Serverless::Function'
+      Properties:
+        Handler: helloworld.index
+        Runtime: nodejs8
+        CodeUri: './'
+      Events:
+        GetResource:
+          Type: API
+          Properties: 
+            Path: '/helloworld'
+            Method: get
+

--- a/examples/java/template.yml
+++ b/examples/java/template.yml
@@ -1,0 +1,14 @@
+ROSTemplateFormatVersion: '2015-09-01'
+Transform: 'Aliyun::Serverless-2018-04-03'
+Resources:
+  java:
+    Type: 'Aliyun::Serverless::Service'
+    Properties:
+      Description: 'java demo'
+    helloworld:
+      Type: 'Aliyun::Serverless::Function'
+      Properties:
+        Handler: example.App::handleRequest
+        Runtime: java8
+        Description: 'Hello world!'
+        CodeUri: './demo.jar'

--- a/examples/openid_connect/template.yml
+++ b/examples/openid_connect/template.yml
@@ -1,0 +1,53 @@
+ROSTemplateFormatVersion: '2015-09-01'
+Transform: 'Aliyun::Serverless-2018-04-03'
+Resources:
+  fc:
+    Type: 'Aliyun::Serverless::Service'
+    Properties:
+      Description: 'fc test'
+    helloworld:
+      Type: 'Aliyun::Serverless::Function'
+      Properties:
+        Handler: helloworld.index
+        CodeUri: './'
+        Description: 'Hello world!'
+      Events:
+        GetApi:
+          Type: API
+          Properties: 
+            Path: /helloworld
+            Method: get
+            RestApiId:
+              Ref: aliyunfcdemo2
+
+  aliyunfcdemo2:
+    Type: 'Aliyun::Serverless::Api'
+    Properties:
+      DefinitionBody:
+        openapi: "3.0.0"
+        info:
+          title: 'API Gateway & Function Compute'
+          version: v1
+        components:
+          securitySchemes:
+            openId:
+              type: openIdConnect
+              name: 'token'
+              in: 'query'
+        '/getUserInfo/[token]':
+          get:
+            security:
+              openId: {}
+            x-aliyun-apigateway-parameters-mapping
+              - from:
+                  name: 'token'
+                  localtion: 'Path'
+                  type: 'String'
+                  requeired: 'REQUIRED'
+                to: 
+                  location: 'Query'
+            x-aliyun-apigateway-visibility: PRIVATE
+            x-aliyun-apigateway-fc:
+              arn: acs:lambda:::services/${fc.Arn}/functions/${helloworld.Arn}/
+              role: acs:ram:::role/aliyunapigatewayaccessingfcrole
+            

--- a/examples/ots_stream/template.yml
+++ b/examples/ots_stream/template.yml
@@ -1,0 +1,18 @@
+ROSTemplateFormatVersion: '2015-09-01'
+Transform: 'Aliyun::Serverless-2018-04-03'
+Resources:
+  otsstream:
+    Type: 'Aliyun::Serverless::Service'
+    Properties:
+      Description: 'Stream trigger for OTS'
+    processor:
+      Type: 'Aliyun::Serverless::Function'
+      Properties:
+        Handler: main.index
+        Runtime: nodejs8
+        CodeUri: './'
+      Events:
+        OtsTrigger:
+          Type: OTS
+          Properties:
+            Stream: acs:ots:cn-hangzhou:123456789012:instance/test_instance/table/test_table

--- a/examples/python/template.yml
+++ b/examples/python/template.yml
@@ -1,0 +1,36 @@
+ROSTemplateFormatVersion: '2015-09-01'
+Transform: 'Aliyun::Serverless-2018-04-03'
+Resources:
+  pythondemo:
+    Type: 'Aliyun::Serverless::Service'
+    Properties:
+      Description: 'python demo'
+    hello:
+      Type: 'Aliyun::Serverless::Function'
+      Properties:
+        Handler: main.hello
+        CodeUri: './'
+        Description: 'Hello world with python!'
+        Runtime: python2.7
+      Events:
+        GetApi:
+          Type: API
+          Properties: 
+            Path: '/python/hello'
+            Method: get
+            RestApiId:
+              Ref: apigw_fc
+
+  apigw_fc:
+    Type: 'Aliyun::Serverless::Api'
+    Properties:
+      DefinitionBody:
+        openapi: "3.0.0"
+        info:
+          title: 'API Gateway & Function Compute'
+          version: v1
+        '/python/hello':
+          get:
+            x-aliyun-apigateway-fc:
+              arn: acs:lambda:::services/${fc.Arn}/functions/${helloworld.Arn}/
+              role: acs:ram:::role/aliyunapigatewayaccessingfcrole

--- a/examples/segment/template.yml
+++ b/examples/segment/template.yml
@@ -1,0 +1,43 @@
+ROSTemplateFormatVersion: '2015-09-01'
+Transform: 'Aliyun::Serverless-2018-04-03'
+Resources:
+  maas:
+    Type: 'Aliyun::Serverless::Service'
+    Properties:
+      Description: 'Module as a service'
+    doSegment:
+      Type: 'Aliyun::Serverless::Function'
+      Properties:
+        Handler: index.doSegment
+        CodeUri: './'
+        Description: 'do segment'
+      Events:
+        GetApi:
+          Type: API
+          Properties: 
+            Path: /do_segement
+            Method: get
+            RestApiId:
+              Ref: maasapi
+
+  maasapi:
+    Type: 'Aliyun::Serverless::Api'
+    Properties:
+      DefinitionBody:
+        openapi: "3.0.0"
+        info:
+          title: 'API Gateway & Function Compute'
+          version: v1
+        'do_segement':
+          post:
+            x-aliyun-apigateway-fc:
+              arn: acs:lambda:::services/${mass.Arn}/functions/${doSegment.Arn}/
+              role: acs:ram:::role/aliyunapigatewayaccessingfcrole
+            requestBody:
+              content:
+                application/octet-stream: 
+                  schema:
+                    type: string
+                    format: binary
+
+            

--- a/examples/timer/template.yml
+++ b/examples/timer/template.yml
@@ -1,0 +1,19 @@
+ROSTemplateFormatVersion: '2015-09-01'
+Transform: 'Aliyun::Serverless-2018-04-03'
+Resources:
+  MyService:
+    Type: 'Aliyun::Serverless::Service'
+    MyFunction:
+      Type: 'Aliyun::Serverless::Function'
+      Properties:
+        Handler: index.handler
+        Runtime: nodejs6.10
+        Description: 'send hangzhou weather'
+        CodeUri: './'
+      Events:
+        TmTrigger:
+          Type: Timer
+          Properties: 
+            Payload: "awesome-fc"
+            CronExpression: "0 0 8 * * *"
+            Enable: true

--- a/examples/wechat/swagger.yml
+++ b/examples/wechat/swagger.yml
@@ -1,0 +1,63 @@
+openapi: "3.0.0"
+info:
+  title: 'API Gateway & Function Compute'
+  version: v1
+components:
+  securitySchemes:
+    openId:
+      type: openIdConnect
+      name: 'token'
+      in: 'query'
+'/wechat':
+  get:
+    x-aliyun-apigateway-parameters-mapping
+      - from:
+          name: 'encrypt_type'
+      - from:
+          name: 'msg_signature'
+      - from:
+          name: 'timestamp'
+          localtion: 'Query'
+          type: 'String'
+          requeired: 'REQUIRED'
+      - from:
+          name: 'nonce'
+          localtion: 'Query'
+          type: 'String'
+      - from:
+          name: 'signature'
+          localtion: 'Query'
+          type: 'String'
+      - from:
+          name: 'echostr'
+          localtion: 'Query'
+          type: 'String'
+    x-aliyun-apigateway-fc:
+      arn: acs:lambda:::services/${wechat.Arn}/functions/${get.Arn}/
+      role: acs:ram:::role/aliyunapigatewayaccessingfcrole
+  post:
+    x-aliyun-apigateway-parameters-mapping
+      - from:
+          name: 'timestamp'
+          localtion: 'Query'
+          type: 'String'
+          requeired: 'REQUIRED'
+      - from:
+          name: 'nonce'
+          localtion: 'Query'
+          type: 'String'
+      - from:
+          name: 'signature'
+          localtion: 'Query'
+          type: 'String'
+      - from:
+          name: 'msg_signature'
+          localtion: 'Query'
+          type: 'String'
+      - from:
+          name: 'encrypt_type'
+          localtion: 'Path'
+          type: 'String'
+    x-aliyun-apigateway-fc:
+      arn: acs:lambda:::services/${wechat.Arn}/functions/${post.Arn}/
+      role: acs:ram:::role/aliyunapigatewayaccessingfcrole

--- a/examples/wechat/template.yml
+++ b/examples/wechat/template.yml
@@ -1,0 +1,44 @@
+ROSTemplateFormatVersion: '2015-09-01'
+Transform: 'Aliyun::Serverless-2018-04-03'
+Resources:
+  wechat:
+    Type: 'Aliyun::Serverless::Service'
+    Properties:
+      Description: 'wechat demo'
+    get:
+      Type: 'Aliyun::Serverless::Function'
+      Properties:
+        Handler: wechat.get
+        CodeUri: './'
+        Runtime: nodejs6
+        Description: 'Wechat get handler'
+      Events:
+        GetApi:
+          Type: API
+          Properties: 
+            Path: /wechat
+            Method: get
+            RestApiId:
+              Ref: wechat_group
+    post:
+      Type: 'Aliyun::Serverless::Function'
+      Properties:
+        Handler: wechat.post
+        CodeUri: './'
+        Runtime: nodejs6
+        Description: 'Wechat post handler'
+      Events:
+        GetApi:
+          Type: API
+          Properties: 
+            Path: /wechat
+            Method: post
+            RestApiId:
+              Ref: wechat_group
+
+  wechat_group:
+    Type: 'Aliyun::Serverless::Api'
+    Properties:
+      DefinitionUri: ./swagger.xml
+        
+            


### PR DESCRIPTION
1. 兼容 ROS 的新 SPEC
2. 遵照新的 Spec 在每个 example 里写了对应的 template.yml。过渡期可以考虑同时兼容 faas.yml 和 template.yml 两种表述。
3. 从最新的 master 上 fork 了一个 spec_for_ros 做了新版本的过渡分支