### PR TITLE
fix bug when using glob pattern '*' or '**/*' of codes properties.

### DIFF
--- a/lib/zip.js
+++ b/lib/zip.js
@@ -3,12 +3,15 @@
 
 const fs = require('fs');
 const path = require('path');
+const util = require('util');
 
 const debug = require('debug')('fun:zip');
 const JSZip = require('jszip');
 const glob = require('glob');
 
 const buildDeps = require('./deps');
+
+const lstat = util.promisify(fs.lstat);
 
 function globAsync(pattern, cwd) {
   return new Promise((resolve, reject) => {
@@ -43,12 +46,15 @@ exports.compress = async function (func, rootDir, type) {
   }
 
   const results = await Promise.all(jobs);
-  results.forEach((list) => {
-    list.forEach((filename) => {
+  for (let list of results) {
+    for (let filename of list) {
       const filepath = path.join(rootDir, filename);
-      zip.file(filename, fs.createReadStream(filepath));
-    });
-  });
+      const stats = await lstat(filepath);
+      if (!stats.isDirectory()) {
+        zip.file(filename, fs.createReadStream(filepath));
+      }
+    }
+  }
 
   return zip.generateAsync({type: 'base64'});
 };


### PR DESCRIPTION
修复 codes 属性无法指定 '*' 和 '**/*' 的 bug。

1. '**' glob 之后的文件列表会包含目录，直接 jszip 一个目录会导致异常退出。所以剔除了目录
2. await 方法在 foreach 中无法使用，改用了 for..of 结构。