### PR TITLE
config travis to auto publish by tag.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ deploy:
     repo: aliyun/fun
     condition: $TRAVIS_TAG = "v$PKG_VERSION"
   before_deploy:
-    - eval "export PKG_VERSION=`node -e \"console.log(require('./package').version)\"`"
+    - export PKG_VERSION=`node -e "console.log(require('./package').version)"`

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ deploy:
     repo: aliyun/fun
     condition: $TRAVIS_TAG = "v$PKG_VERSION"
   before_deploy:
-    - export PKG_VERSION=`node -e "console.log(require('./package').version)"`
+    - export PKG_VERSION=`node -p "require('./package').version"`

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,20 @@
 language: node_js
 node_js:
-  - "8"
-  - "9"
-  - "10"
-
+- '8'
+- '9'
+- '10'
 cache:
   directories:
-    - "node_modules"
-
+  - node_modules
 script: make test
+deploy:
+  provider: npm
+  email: duwan@live.com
+  api_key:
+    secure: UJ7hrwXNo/nEDdvtEfwuX7s1lR0vW1Nd9tq4AmeIxG3KtKBAyglfvh/lPKN5eiO4M9Xga2mLNumNgzk6htZc6zUmKBS/uyDP/BfZFZJDkjfUdDl6l5JtLfSXaWBUSHGM2HoqMXoMrQ0RweT565G4hNDSZ/9vt6DjzCp+twOsKeQWqptcTQxgVk19ynz1Ve0dll/ViIxM04R5vWD9ISI6mHjK1lhcrzsw/HMDimzbOoAtyDSWTwconnv23tY5xCgaTSc4Ltvvlq6pQ9Mtt0mHTkFj+q3B16GeqTiHPjk1MVnPBii9Y/MgdeLkz5RDLggTD5/UzhEtqj8O+dTght4O4uRb7pqLCxVzi5atETvSim+Phsc3y159lQmqmcU/bNXl54C1ro44eBlS1jC8gTrK+c5eBAhju2AOBuoMfmNWHc+sXJLxwaW/o+3alsPeTvpYBlJnU2/LpEpWGohjEUAItyMHtp5nhBXCSf3iQAEXN02fRzj8L+fydTPRFzFnNlGB/qZNGxVIjR9JIaUL8a/DjE5Sjt6OXnNofP7CGMZxSStHVyobo0D36gW/4hRR9kymunvdOoKLmk+E1/0A6vutjOf3ajIdDvr9cfEgHFp9X3cl38WHBwNiQOlJxlE+AooMHgtCiO3+ZFcTsae/EJS3p4KOh+Fx+uBEg3aXT6gqa3Y=
+  on:
+    tags: true
+    repo: aliyun/fun
+    condition: $TRAVIS_TAG = "v$PKG_VERSION"
+  before_deploy:
+    - eval "export PKG_VERSION=`node -e \"console.log(require('./package').version)\"`"


### PR DESCRIPTION
配置 travis 基于 tag 自动发布。发布条件为 tag 的版本版本号和 package.json 里声明的 version 值一致。

比如 package.json 里的 version 值为 2.0.2 那么 tag 值为 v2.0.2 时，会触发自动发布。

查资料盲写的，需要等待下一次发布验证其正确性。