### PR TITLE
示例中的openIdApiType中的id的i需要大写

### DIFF
--- a/examples/openid_connect/template.yml
+++ b/examples/openid_connect/template.yml
@@ -30,7 +30,7 @@ Resources:
             x-aliyun-apigateway-auth-type: 'APPOPENID'
             x-aliyun-apigateway-open-id-connect-config:
               idTokenParamName: 'token'
-              openidApiType: 'BUSINESS'
+              openIdApiType: 'BUSINESS'
             x-aliyun-apigateway-fc:
               arn: acs:fc:::services/${fc.Arn}/functions/${helloworld.Arn}/
             

--- a/test/deploy/deploy-by-tpl.test.js
+++ b/test/deploy/deploy-by-tpl.test.js
@@ -148,7 +148,7 @@ describe('deploy', () => {
       auth: {
         config: {
           'idTokenParamName': 'token',
-          'openidApiType': 'BUSINESS'
+          'openIdApiType': 'BUSINESS'
         },
         type: 'APPOPENID'
       },


### PR DESCRIPTION
按照之前的代码设置了`openidApiType`为`IDTOKEN`，但是用`fun deploy`时一直报错
```shell
The IdTokenParamName is mandatory for this action.
```
看了[文档](https://www.alibabacloud.com/help/zh/doc-detail/61459.htm#h2-openidconnectconfig-13)之后终于发现文档中写的是`OpenIdApiType`，试了之后部署成功。
