### PR TITLE
improve install

### DIFF
--- a/bin/fun-install.js
+++ b/bin/fun-install.js
@@ -40,12 +40,12 @@ program
     install(packageNames, opts).catch(handler);
   });
 
-  program
+program
   .command('init')
   .description('initialize fun.yml file.')
   .action(init);
 
-  program
+program
   .command('env')
   .description('print environment varables.')
   .action(env);

--- a/bin/fun-install.js
+++ b/bin/fun-install.js
@@ -16,7 +16,7 @@ program
   .usage('[moduleNames...]')
   .option('-r, --runtime <runtime>', 'function runtime, avaliable choice is: python2.7, python3, nodejs6, nodejs8, java8, php7.2')
   .option('--save', 'add module to fun.yml file.')
-  .option('-r, --recursive', 'recursive install fun.yml in subdirectory.')
+  .option('-R, --recursive', 'recursive install fun.yml in subdirectory.')
   .option('-p, --package-type <type>', 'avaliable package type option: module, pip, apt, defautls to \'module\'')
   .arguments('[packageNames...]')
   .description('install dependencies which are described in fun.yml file.')
@@ -53,8 +53,8 @@ program
 program.parse(process.argv);
   
 if (!program.args.length) {
-  installAll({
-    recursive: program.options.recursive,
+  installAll(process.cwd(), {
+    recursive: program.recursive,
     verbose: parseInt(process.env.FUN_VERBOSE) > 0
   }).catch(handler);
 }

--- a/bin/fun-install.js
+++ b/bin/fun-install.js
@@ -6,7 +6,7 @@ const handler = require('../lib/exception-handler');
 const _ = require('lodash');
 const Command = require('commander').Command;
 const program = new Command('fun install');
-const { install, installAll, init } = require('../lib/commands/install');
+const { install, installAll, init, env } = require('../lib/commands/install');
 
 const optDefaults = {
   packageType: 'module'
@@ -18,7 +18,6 @@ program
   .option('--save', 'add module to fun.yml file.')
   .option('-r, --recursive', 'recursive install fun.yml in subdirectory.')
   .option('-p, --package-type <type>', 'avaliable package type option: module, pip, apt, defautls to \'module\'')
-  .option('-v', 'show more detail.')
   .arguments('[packageNames...]')
   .description('install dependencies which are described in fun.yml file.')
   .action(async (packageNames, program) => {
@@ -36,19 +35,26 @@ program
       console.error('--recursive option can only be used without arguments.');
     }
 
+    opts.verbose = parseInt(process.env.FUN_VERBOSE) > 0;
+
     install(packageNames, opts).catch(handler);
-  })
+  });
+
+  program
   .command('init')
   .description('initialize fun.yml file.')
   .action(init);
+
+  program
+  .command('env')
+  .description('print environment varables.')
+  .action(env);
   
 program.parse(process.argv);
   
-if (!program.args.length) { 
-
+if (!program.args.length) {
   installAll({
     recursive: program.options.recursive,
-    verbose: program.options.verbose
+    verbose: parseInt(process.env.FUN_VERBOSE) > 0
   }).catch(handler);
-
 }

--- a/bin/fun.js
+++ b/bin/fun.js
@@ -8,12 +8,12 @@ const program = require('commander');
 const debug = require('debug');
 
 program
-  .version(require('../package.json').version, '-v, --version')
+  .version(require('../package.json').version, '--version')
   .description(
     `The fun command line providers a complete set of commands to define, develop, test
   serverless applications locally, and deploy them to the Alibaba Cloud.`
   )
-  .option('--verbose', 'verbose output')
+  .option('-v, --verbose', 'verbose output', (_, total) => total + 1, 0)
   // See git-style sub-commands https://github.com/tj/commander.js/#git-style-sub-commands.
   // See source code: https://github.com/tj/commander.js/blob/master/index.js#L525-L570.
 
@@ -27,8 +27,14 @@ program
   .command('validate', 'validate a fun template')
   .command('deploy', 'deploy a fun application');
 
+// set default verbose value for subcommand.
+process.env.FUN_VERBOSE = 0
+
 program.on('option:verbose', () => {
-  debug.enable('*');
+  if (program.verbose == 4) {
+    debug.enable('*');
+  }
+  process.env.FUN_VERBOSE = program.verbose;
 });
 
 // Print help information if commands are unknown.
@@ -39,5 +45,5 @@ program.on('command:*', (cmds) => {
     program.help();
   }
 });
- 
+
 program.parse(process.argv);

--- a/bin/fun.js
+++ b/bin/fun.js
@@ -28,10 +28,10 @@ program
   .command('deploy', 'deploy a fun application');
 
 // set default verbose value for subcommand.
-process.env.FUN_VERBOSE = 0
+process.env.FUN_VERBOSE = 0;
 
 program.on('option:verbose', () => {
-  if (program.verbose == 4) {
+  if (program.verbose === 4) {
     debug.enable('*');
   }
   process.env.FUN_VERBOSE = program.verbose;

--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -11,26 +11,6 @@ const { installPackage, installFromYaml } = require('../install/install');
 const { FunModule, FunTask } = require('../install/module');
 const { addEnv } = require('../install/env');
 
-
-async function installAll(dir, { recursive, verbose }) {
-
-  if (recursive) {
-    const yamlFiles = await findYamlFiles(dir);
-    for(let ymlPath of yamlFiles){
-      console.log("install on %s", cyan(path.relative(dir, ymlPath)));
-      await installFromYaml(ymlPath, verbose);
-    }
-  } else {
-    let ymlPath = path.join(dir, 'fun.yml');
-    if (fs.existsSync(ymlPath)) {
-      await installFromYaml(ymlPath, verbose);
-    } else {
-      console.error('Can\'t find \'fun.yml\' in current dir.');
-      return;
-    }
-  }
-}
-
 async function findYamlFiles(dir) {
   return new Promise((resolve, reject) => {
     let yamlFiles = [];
@@ -45,9 +25,29 @@ async function findYamlFiles(dir) {
         }
       }
     }).on('end', () => resolve(yamlFiles))
-    .on('error', (err) => reject(err));
-  })
+      .on('error', (err) => reject(err));
+  });
 }
+
+async function installAll(dir, { recursive, verbose }) {
+
+  if (recursive) {
+    const yamlFiles = await findYamlFiles(dir);
+    for(let ymlPath of yamlFiles){
+      console.log('install on %s', cyan(path.relative(dir, ymlPath)));
+      await installFromYaml(ymlPath, verbose);
+    }
+  } else {
+    let ymlPath = path.join(dir, 'fun.yml');
+    if (fs.existsSync(ymlPath)) {
+      await installFromYaml(ymlPath, verbose);
+    } else {
+      console.error('Can\'t find \'fun.yml\' in current dir.');
+      return;
+    }
+  }
+}
+
 
 function getRuntime(options) {
   let moduleRuntime;
@@ -81,20 +81,20 @@ async function save(runtime, codeUri, pkgType, packages) {
 
   for (const pkg of packages) {
     switch (pkgType) {
-      case 'pip':
-        funModule.addTask(new FunTask('pip', {
-          pip: pkg,
-          local: true
-        }));
-        break;
-      case 'apt':
-        funModule.addTask(new FunTask('apt', {
-          apt: pkg,
-          local: true
-        }));
-        break;
-      default:
-        console.error('unknown task %s => %s', pkgType, pkg);
+    case 'pip':
+      funModule.addTask(new FunTask('pip', {
+        pip: pkg,
+        local: true
+      }));
+      break;
+    case 'apt':
+      funModule.addTask(new FunTask('apt', {
+        apt: pkg,
+        local: true
+      }));
+      break;
+    default:
+      console.error('unknown task %s => %s', pkgType, pkg);
     }
   }
 
@@ -121,8 +121,8 @@ async function install(packages, options) {
 async function init() {
 
   if (fs.existsSync('./fun.yml')) {
-    console.error("fun.yml already exist.");
-    return
+    console.error('fun.yml already exist.');
+    return;
   }
 
   const answers = await inquirer.prompt([{

--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -5,10 +5,11 @@ const debug = require('debug')('fun:install');
 const inquirer = require('inquirer');
 const fs = require('fs');
 const path = require('path');
-const {red} = require('colors');
+const { red, green, cyan } = require('colors');
 
 const { installPackage, installFromYaml } = require('../install/install');
 const { FunModule, FunTask } = require('../install/module');
+const { addEnv } = require('../install/env');
 
 
 async function installAll({ recursive, verbose }) {
@@ -42,14 +43,16 @@ function getRuntime(options) {
     moduleRuntime = FunModule.load('./fun.yml').runtime;
   }
 
-  if(options.runtime) {
-    if(moduleRuntime && options.runtime !== moduleRuntime){
+  if (options.runtime) {
+    if (moduleRuntime && options.runtime !== moduleRuntime) {
       throw new Error(red(`'${options.runtime}' specified by --runtime option doesn't match the one in fun.yml.`));
     }
     return options.runtime;
-  } 
+  } else if (moduleRuntime) {
+    return moduleRuntime;
+  }
   throw new Error(red('\'runtime\' is missing, you should specify it by --runtime option.'));
-  
+
 
 }
 
@@ -65,20 +68,20 @@ async function save(runtime, codeUri, pkgType, packages) {
 
   for (const pkg of packages) {
     switch (pkgType) {
-    case 'pip':
-      funModule.addTask(new FunTask('pip', {
-        pip: pkg,
-        local: true
-      }));
-      break;
-    case 'apt':
-      funModule.addTask(new FunTask('apt', {
-        apt: pkg,
-        local: true
-      }));
-      break;
-    default:
-      console.error('unknown task %s => %s', pkgType, pkg);
+      case 'pip':
+        funModule.addTask(new FunTask('pip', {
+          pip: pkg,
+          local: true
+        }));
+        break;
+      case 'apt':
+        funModule.addTask(new FunTask('apt', {
+          apt: pkg,
+          local: true
+        }));
+        break;
+      default:
+        console.error('unknown task %s => %s', pkgType, pkg);
     }
   }
 
@@ -102,25 +105,34 @@ async function install(packages, options) {
   }
 }
 
-
-
-
-
 async function init() {
+
+  if (fs.existsSync('./fun.yml')) {
+    console.error("fun.yml already exist.");
+    return
+  }
+
   const answers = await inquirer.prompt([{
     type: 'list',
-    message: 'Select runtime',
+    message: 'Select a runtime',
     name: 'runtime',
     choices: ['python2.7', 'python3', 'nodejs6', 'nodejs8', 'java8', 'php7.2']
   }]);
 
   const funModule = new FunModule(answers.runtime);
-
   FunModule.store('./fun.yml', funModule);
+}
+
+function env() {
+  const envs = addEnv({});
+  for (let [key, val] of Object.entries(envs)) {
+    console.log(`${green(key)}=${cyan(val)}`);
+  }
 }
 
 module.exports = {
   install,
   installAll,
   init,
+  env,
 };

--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -1,6 +1,6 @@
 'use strict';
 
-// const findit = require('findit2');
+const findit = require('findit2');
 const debug = require('debug')('fun:install');
 const inquirer = require('inquirer');
 const fs = require('fs');
@@ -12,28 +12,41 @@ const { FunModule, FunTask } = require('../install/module');
 const { addEnv } = require('../install/env');
 
 
-async function installAll({ recursive, verbose }) {
-  const cd = process.cwd();
-  const ymlPath = path.join(cd, 'fun.yml');
+async function installAll(dir, { recursive, verbose }) {
 
-  if (!recursive) {
+  if (recursive) {
+    const yamlFiles = await findYamlFiles(dir);
+    for(let ymlPath of yamlFiles){
+      console.log("install on %s", cyan(path.relative(dir, ymlPath)));
+      await installFromYaml(ymlPath, verbose);
+    }
+  } else {
+    let ymlPath = path.join(dir, 'fun.yml');
     if (fs.existsSync(ymlPath)) {
-      installFromYaml(ymlPath, verbose);
+      await installFromYaml(ymlPath, verbose);
     } else {
       console.error('Can\'t find \'fun.yml\' in current dir.');
       return;
     }
-  } else {
-    //TODO
-    console.error('option `--recurive` is unsupported now.');
-    return;
-    // const finder = findit(cd, { followSymlinks: 'true' });
-
-    // finder.on('directory', function (dir, stat, stop, linkPath) {
-
-    // });
   }
+}
 
+async function findYamlFiles(dir) {
+  return new Promise((resolve, reject) => {
+    let yamlFiles = [];
+    findit(dir).on('directory', (subdir, stat, stop, linkPath) => {
+      var base = path.basename(subdir);
+      if (['.git', 'node_modules', '.fun', '.vscode'].includes(base)) {
+        stop();
+      } else {
+        let ymlPath = path.join(subdir, 'fun.yml');
+        if (fs.existsSync(ymlPath)) {
+          yamlFiles.push(ymlPath);
+        }
+      }
+    }).on('end', () => resolve(yamlFiles))
+    .on('error', (err) => reject(err));
+  })
 }
 
 function getRuntime(options) {


### PR DESCRIPTION
1.  增加 fun install env 子命令，以打印附加环境变量，给那些不用 fun deploy 的用户使用
2. 改进 verbose，支持 -vvvv， 目前 -vvvv 才会显示所有 debug 信息。使用 FUN_VERBOSE 环境变量传递 verbose 参数给子命令。
3. 支持 fun install --recursive 当前目录递归安装。