### PR TITLE
Work around edge invoke hanging on Windows

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -34,7 +34,7 @@
     "no-delete-var": 2,
     "no-shadow-restricted-names": 2,
     "no-undef-init": 2,
-    "no-use-before-define": 2,
+    "no-use-before-define": 0,
     "no-unused-vars": [2, {"args": "none"}],
     "no-undef": 2,
     "callback-return": [2, ["callback", "cb", "next"]],

--- a/bin/fun-edge-invoke.js
+++ b/bin/fun-edge-invoke.js
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+
+/* eslint-disable quotes */
+
+'use strict';
+
+const program = require('commander');
+
+program
+  .name('fun edge invoke')
+  .description(
+    `Execute your function in a local Link IoT Edge environment which replicates the release
+  environment almost identically. You can pass in the event body via stdin or by using
+  the -e (--event) parameter.`)
+  .usage('[options] <[service/]function>')
+  .option('--debug',
+    `specify your function executes in debug mode, and listens
+                           on port 5700 at localhost for debuggers to connect`)
+  .option('-e, --event <path>',
+    `a file containing event data passed to the function during
+                           invoke, If this option is not specified, it defaults to
+                           reading event from stdin`)
+  .option('--output-debugger-configs',
+    `output configurations for debuggers, currently only vscode`)
+  .parse(process.argv);
+
+if (!program.args.length) {
+  console.error();
+  console.error("  error: missing required argument `%s'", '[service/]function');
+  program.help();
+}
+
+if (!program.args.length > 1) {
+  console.error();
+  console.error("  error: unexpected argument `%s'", program.args[1]);
+  program.help();
+}
+
+// The debug port can't be configured at present since the debugging container is
+// pre-created. It will be supported when the debugging container is created according
+// to the template.yaml.
+if (program.debug) {
+  program.debugPort = '5700';
+}
+if (program.debugPort) {
+  const debugPort = parseInt(program.debugPort);
+  if (Number.isNaN(debugPort)) {
+    console.error();
+    console.error("  error: not a number `%s'", program.debugPort);
+    console.error();
+    process.exit(-1);
+  }
+  program.debugPort = debugPort;
+}
+
+program.event = program.event || '-';
+
+require('../lib/commands/edge/invoke')(program.args[0], program)
+  .catch(require('../lib/exception-handler'));
+

--- a/bin/fun-edge-invoke.js
+++ b/bin/fun-edge-invoke.js
@@ -15,13 +15,17 @@ program
   .usage('[options] <[service/]function>')
   .option('--debug',
     `specify your function executes in debug mode, and listens
-                           on port 5700 at localhost for debuggers to connect`)
+                             on port 5700 at localhost for debuggers to connect`)
   .option('-e, --event <path>',
     `a file containing event data passed to the function during
-                           invoke, If this option is not specified, it defaults to
-                           reading event from stdin`)
+                             invoke, If this option is not specified, it defaults to
+                             reading event from stdin`)
+  .option('-c, --config <ide/debugger>',
+    `output configurations for the specified ide/debugger, where
+                             the ide/debugger can currently only be vscode`)
   .option('--output-debugger-configs',
-    `output configurations for debuggers, currently only vscode`)
+    `output configurations for all debuggers. It will override
+                             the behavior of --config option`)
   .parse(process.argv);
 
 if (!program.args.length) {
@@ -51,6 +55,17 @@ if (program.debugPort) {
     process.exit(-1);
   }
   program.debugPort = debugPort;
+}
+
+// Check config values.
+if (program.config) {
+  if (program.config !== 'vscode') {
+    console.error();
+    console.error("  error: invalid value `%s'", program.config);
+    console.error();
+    process.exit(-1);
+  }
+  program.outputDebuggerConfigs = true;
 }
 
 program.event = program.event || '-';

--- a/bin/fun-edge-start.js
+++ b/bin/fun-edge-start.js
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+
+/* eslint-disable quotes */
+
+'use strict';
+
+const program = require('commander');
+
+program
+  .name('fun edge start')
+  .description(
+    `Launch one local Link IoT Edge environment for development & testing, or create one
+  if none exist.`)
+  .parse(process.argv);
+
+if (program.args.length) {
+  console.error();
+  console.error("  error: unexpected argument `%s'", program.args[1]);
+  program.help();
+}
+
+require('../lib/commands/edge/start')()
+  .catch(require('../lib/exception-handler'));

--- a/bin/fun-edge-stop.js
+++ b/bin/fun-edge-stop.js
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+
+/* eslint-disable quotes */
+
+'use strict';
+
+const program = require('commander');
+
+program
+  .name('fun edge stop')
+  .description('Stop the local Link IoT Edge environment.')
+  .parse(process.argv);
+
+if (program.args.length) {
+  console.error();
+  console.error("  error: unexpected argument `%s'", program.args[1]);
+  program.help();
+}
+
+require('../lib/commands/edge/stop')()
+  .catch(require('../lib/exception-handler'));

--- a/bin/fun-edge.js
+++ b/bin/fun-edge.js
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+
+/* eslint-disable quotes */
+
+'use strict';
+
+const program = require('commander');
+
+program
+  .name('fun edge')
+  .description(
+    `Run your serverless application at edge (within local Link IoT Edge environment) for
+  quick development & testing.`)
+  .command('invoke', 'invoke a function at edge once')
+  .command('start', 'launch one local Link IoT Edge environment, or create one if none exist')
+  .command('stop', 'stop the local Link IoT Edge environment');
+
+// Print help information if commands are unknown.
+program.on('command:*', (cmds) => {
+  if (!program.commands.map((command) => command.name()).includes(cmds[0])) {
+    console.error();
+    console.error("  error: unknown command `%s'", cmds[0]);
+    program.help();
+  }
+});
+
+program.parse(process.argv);

--- a/bin/fun-local-invoke.js
+++ b/bin/fun-local-invoke.js
@@ -17,7 +17,9 @@ program
     `specify the sandboxed container starting in debug mode,
                              and exposing this port on localhost`)
   // todo: add auto option to auto config vscode
-  .option('-c, --config <ide/debugger>', 'output ide debug configuration. Options are vscode')
+  .option('-c, --config <ide/debugger>',
+    `output configurations for the specified ide/debugger, where
+                             the ide/debugger can currently only be vscode`)
   .option('-e, --event <path>',
     `a file containing event data passed to the function during
                              invoke, If this option is not specified, it defaults to

--- a/bin/fun-local-invoke.js
+++ b/bin/fun-local-invoke.js
@@ -11,14 +11,17 @@ program
   .description(
     `Execute your function in a local environment which replicates the live environment
   almost identically. You can pass in the event body via stdin or by using the -e (--event)
-  parameter.`
-  )
+  parameter.`)
   .usage('[options] <[service/]function>')
-  .option('-d, --debug-port <port>', 'specify the sandboxed container starting in debug' +
-                                     ' mode, and exposing this port on localhost')
+  .option('-d, --debug-port <port>',
+    `specify the sandboxed container starting in debug mode,
+                             and exposing this port on localhost`)
   // todo: add auto option to auto config vscode
   .option('-c, --config <ide/debugger>', 'output ide debug configuration. Options are vscode')
-  .option('-e, --event <path>', 'event file containing event data passed to the function')
+  .option('-e, --event <path>',
+    `a file containing event data passed to the function during
+                             invoke, If this option is not specified, it defaults to
+                             reading event from stdin`)
   .parse(process.argv);
 
 if (!program.args.length) {
@@ -32,6 +35,8 @@ if (!program.args.length > 1) {
   console.error("  error: unexpected argument '%s'", program.args[1]);
   program.help();
 }
+
+program.event = program.event || '-';
 
 require('../lib/commands/local/invoke')(program.args[0], program)
   .then(() =>  {

--- a/bin/fun.js
+++ b/bin/fun.js
@@ -10,7 +10,7 @@ const debug = require('debug');
 program
   .version(require('../package.json').version, '--version')
   .description(
-    `The fun command line providers a complete set of commands to define, develop, test
+    `The fun command line provides a complete set of commands to define, develop, test
   serverless applications locally, and deploy them to the Alibaba Cloud.`
   )
   .option('-v, --verbose', 'verbose output', (_, total) => total + 1, 0)

--- a/bin/fun.js
+++ b/bin/fun.js
@@ -24,6 +24,7 @@ program
   .command('install', 'install dependencies which are described in fun.yml')
   .command('build', 'build the dependencies')
   .command('local', 'run your serverless application locally')
+  .command('edge', 'run your serverless application at edge')
   .command('validate', 'validate a fun template')
   .command('deploy', 'deploy a fun application');
 

--- a/bin/fun.js
+++ b/bin/fun.js
@@ -42,7 +42,7 @@ program.on('option:verbose', () => {
 program.on('command:*', (cmds) => {
   if (!program.commands.map((command) => command.name()).includes(cmds[0])) {
     console.error();
-    console.error("  error: unknown command '%s'", cmds[0]);
+    console.error("  error: unknown command `%s'", cmds[0]);
     program.help();
   }
 });

--- a/lib/commands/edge/invoke.js
+++ b/lib/commands/edge/invoke.js
@@ -1,0 +1,85 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const readline = require('readline');
+const debug = require('debug')('edge:invoke');
+
+const validate = require('../../validate/validate');
+const LocalRunner = require('../../edge/runner');
+const LocalRuntime = require('../../edge/runtime');
+const FunctionIdentifier = require('../../function-identifier');
+const { detectTplPath, getTpl } = require('../../tpl');
+const { getProfile } = require('../../profile');
+
+async function invoke(name, options) {
+  // Convert name string to FunctionId.
+  const identifier = new FunctionIdentifier(name);
+
+  const templateFile = await detectTplPath();
+  if (!templateFile || !path.basename(templateFile).startsWith('template')) {
+    console.error(`Error: Can't find template file at ${templateFile}.`);
+    process.exit(-1);
+  }
+  console.log(`Using template file at ${templateFile}.`);
+  const { valid, ajv } = await validate(templateFile);
+  if (!valid) {
+    console.error(JSON.stringify(ajv.errors, null, 2));
+    process.exit(-1);
+  }
+  const template = await getTpl(templateFile);
+
+  const cwd = path.dirname(templateFile);
+  debug(`Current working directory: ${cwd}`);
+
+  const event = await getEvent(options.event);
+  debug(`Got event ${event}`);
+
+  const profile = await getProfile();
+  debug(`Found profile: ${JSON.stringify(profile)}`);
+
+  const runtime = new LocalRuntime();
+  const localRunner = new LocalRunner({
+    cwd,
+    runtime,
+    template,
+    profile,
+    debugInfo: {
+      debugPort: options.debugPort,
+      outputDebuggerConfigs: options.outputDebuggerConfigs,
+    },
+  });
+  await localRunner.invoke(identifier, event);
+}
+
+/**
+ * Get event content from a file. It reads event from stdin if the file is "-".
+ *
+ * @param file the file from which to read the event content, or "-" to read from stdin.
+ * @returns {Promise<String>}
+ */
+function getEvent(file) {
+  return new Promise((resolve) => {
+    let input;
+    if (file === '-') {
+      console.log(`Reading event data from stdin (you can also pass it from file with -e)`);
+      input = process.stdin;
+    } else {
+      input = fs.createReadStream(file, {
+        encoding: 'utf-8',
+      });
+    }
+    const rl = readline.createInterface({
+      input,
+    });
+    let event = '';
+    rl.on('line', (line) => {
+      event += line;
+    });
+    rl.on('close', () => {
+      resolve(event);
+    });
+  });
+}
+
+module.exports = invoke;

--- a/lib/commands/edge/invoke.js
+++ b/lib/commands/edge/invoke.js
@@ -71,6 +71,7 @@ function getEvent(file) {
     }
     const rl = readline.createInterface({
       input,
+      output: process.stdout,
     });
     let event = '';
     rl.on('line', (line) => {
@@ -78,6 +79,11 @@ function getEvent(file) {
     });
     rl.on('close', () => {
       resolve(event);
+    });
+    rl.on('SIGINT', function () {
+      // Keep the behavior consistent with system.
+      process.stdout.write('^C');
+      process.exit(-1);
     });
   });
 }

--- a/lib/commands/edge/invoke.js
+++ b/lib/commands/edge/invoke.js
@@ -62,7 +62,8 @@ function getEvent(file) {
   return new Promise((resolve) => {
     let input;
     if (file === '-') {
-      console.log(`Reading event data from stdin (you can also pass it from file with -e)`);
+      console.log(`Reading event data from stdin, which can be ended with Enter then Ctrl+D
+(you can also pass it from file with -e)`);
       input = process.stdin;
     } else {
       input = fs.createReadStream(file, {

--- a/lib/commands/edge/start.js
+++ b/lib/commands/edge/start.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const Container = require('../../edge/container');
+
+/**
+ * Start a edge container instance.
+ *
+ * @returns {Promise.<void>}
+ */
+async function start() {
+  const container = Container.edge();
+  await container.start();
+}
+
+module.exports = start;

--- a/lib/commands/edge/stop.js
+++ b/lib/commands/edge/stop.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const Container = require('../../edge/container');
+
+/**
+ * Stop the running edge container instance.
+ *
+ * @returns {Promise.<void>}
+ */
+async function stop() {
+  const container = Container.edge();
+  container.stop();
+}
+
+module.exports = stop;

--- a/lib/commands/local/http-support.js
+++ b/lib/commands/local/http-support.js
@@ -1,6 +1,5 @@
 'use strict';
 
-
 const debug = require('debug')('fun:local');
 
 const { green, yellow } = require('colors');

--- a/lib/commands/local/invoke.js
+++ b/lib/commands/local/invoke.js
@@ -5,7 +5,7 @@ const path = require('path');
 const debug = require('debug')('fun:local');
 
 const validate = require('../../validate/validate');
-const getStdin = require('get-stdin');
+const readline = require('readline');
 const definition = require('../../definition');
 const { getDebugPort, getDebugIde } = require('../../debug');
 
@@ -56,27 +56,28 @@ async function localInvoke(invokeName, tpl, debugPort, event, debugIde, tplPath)
   await localInvoke.invoke(event);
 }
 
-async function getEventContent(options) {
-  const eventFile = options.event;
-
-  let event = await getStdin();
-
-  if (event && eventFile) {
-    console.error(red('-e or stdin only one can be provided'));
-    process.exit(1);
-  }
-
-  if (eventFile) {
-    event = fs.readFileSync(eventFile, 'utf8');
-  }
-
-  if (!event) {
-    event = '{}';
-  }
-
-  debug('use event: ' + event);
-
-  return event;
+function getEvent(file) {
+  return new Promise((resolve) => {
+    let input;
+    if (file === '-') {
+      console.log(`Reading event data from stdin (you can also pass it from file with -e)`);
+      input = process.stdin;
+    } else {
+      input = fs.createReadStream(file, {
+        encoding: 'utf-8',
+      });
+    }
+    const rl = readline.createInterface({
+      input,
+    });
+    let event = '';
+    rl.on('line', (line) => {
+      event += line;
+    });
+    rl.on('close', () => {
+      resolve(event);
+    });
+  });
 }
 
 async function invoke(invokeName, options) {
@@ -98,7 +99,7 @@ async function invoke(invokeName, options) {
 
     const tpl = await getTpl(tplPath);
 
-    const event = await getEventContent(options);
+    const event = await getEvent(options.event);
 
     debug('event content: ' + event);
 

--- a/lib/commands/local/invoke.js
+++ b/lib/commands/local/invoke.js
@@ -66,7 +66,8 @@ function getEvent(file) {
   return new Promise((resolve) => {
     let input;
     if (file === '-') {
-      console.log(`Reading event data from stdin (you can also pass it from file with -e)`);
+      console.log(`Reading event data from stdin, which can be ended with Enter then Ctrl+D
+(you can also pass it from file with -e)`);
       input = process.stdin;
     } else {
       input = fs.createReadStream(file, {

--- a/lib/commands/local/invoke.js
+++ b/lib/commands/local/invoke.js
@@ -13,8 +13,6 @@ const { detectTplPath, getTpl } = require('../../tpl');
 
 const { red } = require('colors');
 
-const LocalInvoke = require('../../local/local-invoke');
-
 function parseInvokeName(invokeName) {
   let serviceName = null;
   let functionName = null;
@@ -51,11 +49,19 @@ async function localInvoke(invokeName, tpl, debugPort, event, debugIde, tplPath)
 
   debug(`found serviceName: ${serviceName}, functionName: ${functionName}, functionRes: ${functionRes}`);
 
+  // Lazy loading to avoid stdin being taken over twice.
+  const LocalInvoke = require('../../local/local-invoke');
   const localInvoke = new LocalInvoke(serviceName, serviceRes, functionName, functionRes, debugPort, debugIde, tplPath);
 
   await localInvoke.invoke(event);
 }
 
+/**
+ * Get event content from a file. It reads event from stdin if the file is "-".
+ *
+ * @param file the file from which to read the event content, or "-" to read from stdin.
+ * @returns {Promise<String>}
+ */
 function getEvent(file) {
   return new Promise((resolve) => {
     let input;
@@ -69,6 +75,7 @@ function getEvent(file) {
     }
     const rl = readline.createInterface({
       input,
+      output: process.stdout,
     });
     let event = '';
     rl.on('line', (line) => {
@@ -76,6 +83,11 @@ function getEvent(file) {
     });
     rl.on('close', () => {
       resolve(event);
+    });
+    rl.on('SIGINT', function () {
+      // Keep the behavior consistent with system.
+      process.stdout.write('^C');
+      process.exit(-1);
     });
   });
 }

--- a/lib/edge/agent.js
+++ b/lib/edge/agent.js
@@ -4,17 +4,22 @@ const debug = require('debug')('edge:agent');
 const https = require('https');
 
 /**
- * A client of function compute service in Link IoT Edge.
+ * A client for requesting function compute service in Link IoT Edge.
  */
-class FunctionCompute {
+class FunctionComputeClient {
 
   /**
    * Create a new client.
    */
   constructor() {
     this._agent = new https.Agent({ keepAlive: true });
-    // Keep the promise.
-    this._login = this.login();
+    // Wrapping the promise with a function due to we want it to be lazy to execute.
+    this._login = () => {
+      if (!this._p) {
+        this._p = this.login();
+      }
+      return this._p;
+    };
   }
 
   /**
@@ -123,7 +128,7 @@ class FunctionCompute {
     debugPort = undefined,
   }) {
     if (!functionId && (!serviceName || !functionName)) {
-      throw new Error(`Either Function id or serviceName/functionName should be provided.`);
+      throw new Error(`Neither Function id nor serviceName/functionName is provided.`);
     }
     const content = {
       DeployParams: {
@@ -148,12 +153,12 @@ class FunctionCompute {
       },
     };
     if (envVars) {
-      content.DeployParams.config.environment = {
+      content.DeployParams.functions[0].config.environment = {
         variables: Object.assign({}, envVars),
       };
     }
     const params = JSON.stringify(this._buildParams(content));
-    const cookie = await this._login;
+    const cookie = await this._login();
     const options = {
       method: 'POST',
       host: 'localhost',
@@ -188,11 +193,11 @@ class FunctionCompute {
           }
         });
       });
-      req.write(params);
       req.on('error', (e) => {
         console.error(`Request to deploy error: ${e}`);
         reject(e);
       });
+      req.write(params);
       req.end();
     });
   }
@@ -221,10 +226,9 @@ class FunctionCompute {
     invokerContext = '',
     event = '{}',
     invocationType = 'Sync',
-    timeout = 70,
   }) {
     if (!functionId && (!serviceName || !functionName)) {
-      throw new Error(`Either Function id or serviceName/functionName should be provided.`);
+      throw new Error(`Neither Function id nor serviceName/functionName is provided.`);
     }
     if (invocationType !== 'Sync' && invocationType !== 'Async') {
       throw new Error(
@@ -245,7 +249,7 @@ class FunctionCompute {
       },
     };
     const params = JSON.stringify(this._buildParams(content));
-    const cookie = await this._login;
+    const cookie = await this._login();
     const options = {
       method: 'POST',
       host: 'localhost',
@@ -258,7 +262,7 @@ class FunctionCompute {
       rejectUnauthorized: false,
     };
 
-    debug(`Invoking: ${params}, timeout: ${timeout}.`);
+    debug(`Invoking: ${params}.`);
 
     return new Promise((resolve, reject) => {
       const req = https.request(options, (res) => {
@@ -271,7 +275,8 @@ class FunctionCompute {
           try {
             let parsed = JSON.parse(raw);
             if (parsed.code === 200) {
-              resolve(Buffer.from(parsed.data, 'base64'));
+              const ret = parsed.data && Buffer.from(parsed.data, 'base64');
+              resolve(ret);
             } else {
               reject(new Error(`${parsed.message}`));
             }
@@ -280,16 +285,16 @@ class FunctionCompute {
           }
         });
       });
-      req.write(params);
       req.on('error', (e) => {
         console.error(`Request to invoke error: ${e}`);
         reject(e);
       });
+      req.write(params);
       req.end();
     });
   }
 }
 
 module.exports = {
-  FunctionCompute,
+  FunctionComputeClient,
 };

--- a/lib/edge/agent.js
+++ b/lib/edge/agent.js
@@ -1,0 +1,295 @@
+'use strict';
+
+const debug = require('debug')('edge:agent');
+const https = require('https');
+
+/**
+ * A client of function compute service in Link IoT Edge.
+ */
+class FunctionCompute {
+
+  /**
+   * Create a new client.
+   */
+  constructor() {
+    this._agent = new https.Agent({ keepAlive: true });
+    // Keep the promise.
+    this._login = this.login();
+  }
+
+  /**
+   * Build parameters to meet the open APIs parameter requirements.
+   *
+   * @param data the content.
+   * @returns {Object}
+   *
+   * @private
+   */
+  _buildParams(data) {
+    return {
+      id: 'id',
+      version: '1.0',
+      request: {
+        apiVer: '0.6',
+      },
+      params: data,
+    };
+  }
+
+  /**
+   * Authenticate the client.
+   *
+   * @returns {Promise<Void>}
+   */
+  async login() {
+    const params = JSON.stringify(
+      this._buildParams({
+        UserName: 'admin',
+        Password: 'admin1234',
+      })
+    );
+    const options = {
+      method: 'POST',
+      host: 'localhost',
+      port: '9999',
+      path: '/auth/login',
+      agent: this._agent,
+      rejectUnauthorized: false,
+    };
+    debug(`Logging in: ${params}.`);
+    return new Promise((resolve, reject) => {
+      const req = https.request(options, (res) => {
+        const cookie = res.headers['set-cookie'];
+        let raw = '';
+        res.on('data', (chunk) => {
+          raw += chunk;
+        });
+        res.on('end', () => {
+          debug(`Login back: ${raw}.`);
+          try {
+            let parsed = JSON.parse(raw);
+            if (parsed.code === 200) {
+              debug(`Login successfully and got cookie ${cookie}.`);
+              resolve(cookie);
+            } else {
+              reject(new Error(`${parsed.message}`));
+            }
+          } catch (err) {
+            reject(new Error('Server Internal Error'));
+          }
+        });
+      });
+      req.on('error', (e) => {
+        console.error(`Request to login error: ${e}`);
+        reject(e);
+      });
+      req.write(params);
+      req.end();
+    });
+  }
+
+  /**
+   * Deploy a function.
+   *
+   * @param functionId the id of the function.
+   * @param serviceName the name of the service.
+   * @param functionName the name of the function.
+   * @param handler the event handler.
+   * @param runtime the runtime for the function. May be nodejs8, python3, c etc.
+   * @param timeout the maximum execution time of event handler.
+   * @param memory the maximum memory size in megabyte that the function can used.
+   * @param codeDir the path where the code is at.
+   * @param accountId the id of the account, to which this function belongs.
+   * @param region the region of the function.
+   * @param pinned whether the function is pinned or not. A pinned function is so-called
+   *               'long-lived' function.
+   * @param envVars the environment variables.
+   * @param debugPort the port for debugger to listen.
+   * @returns {Promise}
+   */
+  async deploy({
+    functionId,
+    serviceName,
+    functionName,
+    handler,
+    runtime,
+    timeout,
+    memory,
+    codeDir,
+    accountId = undefined,
+    region = undefined,
+    pinned = false,
+    envVars = undefined,
+    debugPort = undefined,
+  }) {
+    if (!functionId && (!serviceName || !functionName)) {
+      throw new Error(`Either Function id or serviceName/functionName should be provided.`);
+    }
+    const content = {
+      DeployParams: {
+        functions: [{
+          debugPort,
+          runEnv: debugPort ? 'develop' : 'release',
+          codePath: codeDir,
+          config: {
+            handler,
+            timeout,
+            functionId,
+            accountId,
+            serviceName,
+            functionName,
+            codeChecksum: '13029137535537259255',
+            memorySize: memory * 1000 * 1000,
+            regionId: region,
+            fcRuntime: runtime,
+            runMode: pinned ? 'LongLived' : 'OnDemand',
+          }
+        }]
+      },
+    };
+    if (envVars) {
+      content.DeployParams.config.environment = {
+        variables: Object.assign({}, envVars),
+      };
+    }
+    const params = JSON.stringify(this._buildParams(content));
+    const cookie = await this._login;
+    const options = {
+      method: 'POST',
+      host: 'localhost',
+      port: '9999',
+      path: '/function_compute/deploy',
+      headers: {
+        cookie,
+      },
+      agent: this._agent,
+      rejectUnauthorized: false,
+    };
+
+    debug(`Deploying: ${params}.`);
+
+    return new Promise((resolve, reject) => {
+      const req = https.request(options, (res) => {
+        let raw = '';
+        res.on('data', (chunk) => {
+          raw += chunk;
+        });
+        res.on('end', () => {
+          debug(`Deploy back: ${raw}.`);
+          try {
+            let parsed = JSON.parse(raw);
+            if (parsed.code === 200) {
+              resolve();
+            } else {
+              reject(new Error(`${parsed.message}`));
+            }
+          } catch (err) {
+            reject(new Error('Server Internal Error'));
+          }
+        });
+      });
+      req.write(params);
+      req.on('error', (e) => {
+        console.error(`Request to deploy error: ${e}`);
+        reject(e);
+      });
+      req.end();
+    });
+  }
+
+  /**
+   * Invoke a function.
+   *
+   * @param functionId the id of the function.
+   * @param functionName the name of the function.
+   * @param serviceName the name of the service in which the function is.
+   * @param accountId the id of the account to which the function belongs.
+   * @param region the region of the function.
+   * @param invokerContext the invoker context, which can be used to provide additional
+   *                       information about invoker.
+   * @param event the event that would be passed to the function.
+   * @param invocationType the type of the invocation. Can be 'Sync' or 'Async'.
+   * @param timeout the maximum time to return. Default is 70.
+   * @returns {Promise}
+   */
+  async invoke({
+    functionId,
+    functionName,
+    serviceName,
+    accountId = undefined,
+    region = undefined,
+    invokerContext = '',
+    event = '{}',
+    invocationType = 'Sync',
+    timeout = 70,
+  }) {
+    if (!functionId && (!serviceName || !functionName)) {
+      throw new Error(`Either Function id or serviceName/functionName should be provided.`);
+    }
+    if (invocationType !== 'Sync' && invocationType !== 'Async') {
+      throw new Error(
+        `Incorrect invocationType ${invocationType}. It should be 'Sync' or 'Async'`
+      );
+    }
+    const base64Event = Buffer.from(event).toString('base64');
+    const content = {
+      InvokeParams: {
+        accountId,
+        functionId,
+        serviceName,
+        functionName,
+        invocationType,
+        regionId: region,
+        context: invokerContext,
+        payload: base64Event,
+      },
+    };
+    const params = JSON.stringify(this._buildParams(content));
+    const cookie = await this._login;
+    const options = {
+      method: 'POST',
+      host: 'localhost',
+      port: '9999',
+      path: '/function_compute/invoke',
+      headers: {
+        cookie,
+      },
+      agent: this._agent,
+      rejectUnauthorized: false,
+    };
+
+    debug(`Invoking: ${params}, timeout: ${timeout}.`);
+
+    return new Promise((resolve, reject) => {
+      const req = https.request(options, (res) => {
+        let raw = '';
+        res.on('data', (chunk) => {
+          raw += chunk;
+        });
+        res.on('end', () => {
+          debug(`Invoke back: ${raw}.`);
+          try {
+            let parsed = JSON.parse(raw);
+            if (parsed.code === 200) {
+              resolve(Buffer.from(parsed.data, 'base64'));
+            } else {
+              reject(new Error(`${parsed.message}`));
+            }
+          } catch (err) {
+            reject(new Error('Server Internal Error'));
+          }
+        });
+      });
+      req.write(params);
+      req.on('error', (e) => {
+        console.error(`Request to invoke error: ${e}`);
+        reject(e);
+      });
+      req.end();
+    });
+  }
+}
+
+module.exports = {
+  FunctionCompute,
+};

--- a/lib/edge/agent.js
+++ b/lib/edge/agent.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const debug = require('debug')('edge:agent');
+const debug = require('debug')('fun:edge:agent');
 const https = require('https');
 
 /**

--- a/lib/edge/agent.js
+++ b/lib/edge/agent.js
@@ -104,6 +104,7 @@ class FunctionComputeClient {
    * @param timeout the maximum execution time of event handler.
    * @param memory the maximum memory size in megabyte that the function can used.
    * @param codeDir the path where the code is at.
+   * @param codeChecksum the crc64-ecma182 checksum of the code archive.
    * @param accountId the id of the account, to which this function belongs.
    * @param region the region of the function.
    * @param pinned whether the function is pinned or not. A pinned function is so-called
@@ -121,6 +122,7 @@ class FunctionComputeClient {
     timeout,
     memory,
     codeDir,
+    codeChecksum = undefined,
     accountId = undefined,
     region = undefined,
     pinned = false,
@@ -143,7 +145,7 @@ class FunctionComputeClient {
             accountId,
             serviceName,
             functionName,
-            codeChecksum: '13029137535537259255',
+            codeChecksum,
             memorySize: memory * 1000 * 1000,
             regionId: region,
             fcRuntime: runtime,

--- a/lib/edge/config.js
+++ b/lib/edge/config.js
@@ -1,0 +1,35 @@
+/* eslint-disable indent */
+
+'use strict';
+
+const DEFAULT_TIMEOUT_SECONDS = 3;
+const DEFAULT_MEMORY = 128;
+
+/**
+ * Data class to store function configuration.
+ */
+class FunctionConfig {
+  constructor({
+    identifier,
+    accountId,
+    region,
+    runtime,
+    handler,
+    timeout = DEFAULT_TIMEOUT_SECONDS,
+    memory = DEFAULT_MEMORY,
+    codeAbsPath,
+    envVars,
+  }) {
+    this.identifier = identifier;
+    this.accountId = accountId;
+    this.region = region;
+    this.runtime = runtime;
+    this.handler = handler;
+    this.timeout = timeout;
+    this.memory = memory;
+    this.codeAbsPath = codeAbsPath;
+    this.envVars = envVars;
+  }
+}
+
+module.exports = FunctionConfig;

--- a/lib/edge/container.js
+++ b/lib/edge/container.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const debug = require('debug')('edge:container');
+const debug = require('debug')('fun:edge:container');
 const Docker = require('dockerode');
 
 /**

--- a/lib/edge/container.js
+++ b/lib/edge/container.js
@@ -1,0 +1,349 @@
+'use strict';
+
+const debug = require('debug')('edge:container');
+const Docker = require('dockerode');
+
+/**
+ * The class represents the local Link IoT Edge container, which provides basic high level
+ * interfaces to interact with it.
+ */
+class Container {
+
+  /**
+   * Return the edge container instance.
+   *
+   * @returns {Container}
+   */
+  static edge(docker = undefined) {
+    return new Container({
+      docker,
+      name: Container._getName(),
+      image: Container._getImage(),
+    });
+  }
+
+  /**
+   * Create a new edge container instance.
+   *
+   * @param image the image of the container.
+   * @param name the name of the container.
+   * @param docker the docker daemon client.
+   */
+  constructor({
+    image,
+    name = undefined,
+    docker = new Docker(),
+  } = {}) {
+    this.image = image;
+    this.name = name;
+    this.docker = docker;
+    // Wrapping the promise with a function due to we want it to be lazy to execute.
+    this.bind = () => {
+      if (!this._p) {
+        this._p = this._bind(image, name);
+      }
+      return this._p;
+    };
+  }
+
+  /**
+   * Start the container. It pulls the image or creates a new container if none existing
+   * respectively.
+   *
+   * @return {Promise.<void>}
+   */
+  async start() {
+    await this.bind();
+    if (!this.isCreated()) {
+      console.log('No local container found，try to create one...');
+      const hasImage = await this.hasImage();
+      if (!hasImage) {
+        await this.pullImage();
+      }
+      await this.create();
+    }
+    if (!this.isRunning()) {
+      const container = this.docker.getContainer(this.id);
+      await container.start();
+      this._running = true;
+      console.log(`Container ${this.name} is started.`);
+    } else {
+      console.log(`Container ${this.name} is running. Skip starting.`);
+    }
+  }
+
+  /**
+   * Stop the container.
+   *
+   * @return {Promise.<void>}
+   */
+  async stop() {
+    await this.bind();
+    if (!this.isCreated()) {
+      console.log('Container is not created. Skip stopping.');
+      return;
+    }
+    if (this.isRunning()) {
+      const container = this.docker.getContainer(this.id);
+      await container.stop();
+      this._running = false;
+      console.log(`Container ${this.name} is stopped.`);
+    } else {
+      console.log(`Container ${this.name} is not running. Skip stopping.`);
+    }
+  }
+
+  /**
+   * Create a new container.
+   *
+   * @returns {Promise.<*>}
+   */
+  async create() {
+    if (this.id) {
+      throw new Error(`This container already exists. Cannot create again.`);
+    }
+    const createOptions = {
+      ExposedPorts: {},
+      HostConfig: {
+        Binds: [],
+        PortBindings: {},
+        Privileged: true,
+      },
+      Volumes: {},
+    };
+    const ports = [5700, 9999];
+    ports.forEach((port) => {
+      createOptions.ExposedPorts[`${port}/tcp`] = {};
+      createOptions.HostConfig.PortBindings[`${port}/tcp`] = [{ HostPort: `${port}` }];
+    });
+    const volumes = [
+      '/usr/.security',
+      '/etc/.sec',
+      '/linkedge/gateway/build/.sst',
+      '/tmp/var/run',
+      '/linkedge/run'
+    ];
+    volumes.forEach((volume, index) => {
+      createOptions.Volumes[volume] = {};
+      createOptions.HostConfig.Binds.push(`linkedge_vol${index + 1}:${volume}`);
+    });
+
+    console.log('\n\nPlease enter secret triples for setup:');
+    const triples = await this._readTriples();
+
+    const setupOptions = Object.assign({}, createOptions);
+    setupOptions.name = 'linkedge-debug-setup';
+    setupOptions.Entrypoint = ['/linkedge/gateway/build/script/set_gw_triple.sh'];
+    setupOptions.HostConfig = Object.assign({}, createOptions.HostConfig, {
+      AutoRemove: true
+    });
+
+    console.log(`Applying secret triples...`);
+    await this.docker.run(this.image, [triples.key, triples.name, triples.secret],
+      process.output, setupOptions);
+    // Wait for 3 seconds ...
+    await new Promise((resolve) => {
+      setTimeout(() => resolve(), 3000);
+    });
+
+    console.log(`Create container with name ${this.name}.`);
+    createOptions.name = this.name;
+    createOptions.Image = this.image;
+    createOptions.RestartPolicy = { name: 'unless-stopped' };
+    const container = await this.docker.createContainer(createOptions);
+    this.id = container.id;
+    return this.id;
+  }
+
+  /**
+   * Return if the container is created or not.
+   *
+   * @returns {boolean}
+   */
+  isCreated() {
+    return !!this.id;
+  }
+
+  isRunning() {
+    return this._running;
+  }
+
+  /**
+   * Extract an archive of files or folders from source on local filesystem to the target
+   * directory in the container.
+   *
+   * @param source a archive of files or folders
+   * @param target the target directory in the container
+   * @returns {Promise.<void>}
+   */
+  async copy(source, target) {
+    await this.bind();
+    if (!this.isCreated()) {
+      throw new Error('No local container found. Please run `fun edge start` to start one.');
+    }
+    if (!this.isRunning()) {
+      throw new Error('Local container is not running. Please run `fun edge start` to start it.');
+    }
+    // Make sure the target path exists.
+    const container = this.docker.getContainer(this.id);
+    const exec = await container.exec({
+      Cmd: ['mkdir', '-p', `${target}`],
+      AttachStdout: true,
+      AttachStderr: true,
+      Tty: true,
+    });
+    const stream = await exec.start({hijack: true});
+    await new Promise((resolve, reject) => {
+      stream.output.on('end', () => {
+        resolve();
+      });
+      stream.output.on('error', (err) => {
+        reject(err);
+      });
+    });
+    // Copy to the target path.
+    await container.putArchive(source, {
+      path: target,
+    });
+  }
+
+  async _bind(image, name = undefined) {
+    debug(`Trying to find a local container ${name} (${image}).`);
+    const options = {
+      all: true,
+      filters: {
+        ancestor: [image],
+      },
+    };
+    if (name) {
+      options.filters.name = [name];
+    }
+    const [head] = await this.docker.listContainers(options);
+    if (head) {
+      this.id = head.Id;
+      this._running = head.State === 'running';
+      debug(`Bound to the local container ${name} (${image}).`);
+    }
+    return head;
+  }
+
+  async _readTriples() {
+    const inquirer = require('inquirer');
+    const questions = [
+      {
+        type: 'input',
+        name: 'key',
+        message: 'Product key',
+        validate: function(value) {
+          if (/^[A-Za-z0-9]{10,}$/.test(value)) {
+            return true;
+          }
+          return 'Please enter a valid product key. Allowed characters: ' +
+            '[A-Za-z0-9], length: at least 10.';
+        },
+      },
+      {
+        type: 'input',
+        name: 'name',
+        message: 'Device name',
+        validate: function(value) {
+          if (/^[\w-@:\.]{4,32}$/.test(value)) {
+            return true;
+          }
+          return 'Please enter a valid device name. Allowed characters: ' +
+            '[A-Za-z0-9_-@:.], length: 4~32.';
+        },
+      },
+      {
+        type: 'password',
+        message: 'Device secret',
+        name: 'secret',
+        mask: '*',
+        validate: function (value) {
+          if (/^[A-Za-z0-9]{32}$/.test(value)) {
+            return true;
+          }
+          return 'Please enter a valid device secret. Allowed characters: ' +
+            '[A-Za-z0-9], length: 32.';
+        }
+      }
+    ];
+    return await inquirer.prompt(questions);
+  }
+
+  /**
+   * Return whether the image is downloaded at local.
+   *
+   * @returns {Promise.<boolean>}
+   */
+  async hasImage() {
+    const images = await this.docker.listImages({
+      filter: {
+        reference: [this.image],
+      }
+    });
+    return !!images.length;
+  }
+
+  /**
+   * Pull the container image from the registry.
+   *
+   * @return {Promise<Void>}
+   */
+  async pullImage() {
+    const stream = await this.docker.pull(this.image);
+    return new Promise((resolve, reject) => {
+      const onFinished = (err) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+        resolve(this.image);
+      };
+      const slog = require('single-line-log').stdout;
+      const statuses = {};
+      const onProgress = (event) => {
+        let status = event.status;
+        if (event.progress) {
+          status = `${event.status} ${event.progress}`;
+        }
+        if (event.id) {
+          statuses[event.id] = status;
+        }
+        // Print
+        let output = '';
+        const keys = Object.keys(statuses);
+        for (const key of keys) {
+          output += key + ': ' + statuses[key] + '\n';
+        }
+        if (!event.id) {
+          output += event.status;
+        }
+        slog(output);
+      };
+      this.docker.modem.followProgress(stream, onFinished, onProgress);
+    });
+  }
+
+  /**
+   * Return the image of the edge container.
+   *
+   * @return {string}
+   * @private
+   */
+  static _getImage() {
+    return 'registry.cn-hangzhou.aliyuncs.com/iotedge/edge_x86_alpine:v1.8.2';
+  }
+
+  /**
+   * Return the name of the edge container.
+   *
+   * @return {string}
+   * @private
+   */
+  static _getName() {
+    return 'linkedge-debug';
+  }
+}
+
+module.exports = Container;

--- a/lib/edge/container.js
+++ b/lib/edge/container.js
@@ -197,13 +197,18 @@ class Container {
       AttachStderr: true,
       Tty: true,
     });
-    const stream = await exec.start({hijack: true});
     await new Promise((resolve, reject) => {
-      stream.output.on('end', () => {
-        resolve();
-      });
-      stream.output.on('error', (err) => {
-        reject(err);
+      exec.start((err, stream) => {
+        stream.on('end', () => {
+          resolve();
+        });
+        stream.on('error', (err) => {
+          reject(err);
+        });
+        // FIXME There is no 'end' event being received on windows. Send one.
+        if (process.platform === 'win32') {
+          setTimeout(() => stream.end(), 0);
+        }
       });
     });
     // Copy to the target path.

--- a/lib/edge/container.js
+++ b/lib/edge/container.js
@@ -252,7 +252,7 @@ class Container {
         name: 'name',
         message: 'Device name',
         validate: function(value) {
-          if (/^[\w-@:\.]{4,32}$/.test(value)) {
+          if (/^[\w-@:.]{4,32}$/.test(value)) {
             return true;
           }
           return 'Please enter a valid device name. Allowed characters: ' +

--- a/lib/edge/container.js
+++ b/lib/edge/container.js
@@ -164,6 +164,11 @@ class Container {
     return !!this.id;
   }
 
+  /**
+   * Return if the container is running or not.
+   *
+   * @returns {boolean|*}
+   */
   isRunning() {
     return this._running;
   }

--- a/lib/edge/runner.js
+++ b/lib/edge/runner.js
@@ -9,9 +9,24 @@ const { findFunctionInTpl } = require('../definition');
 const Function = require('../function');
 const FunctionConfig = require('./config');
 
+/**
+ * Maximum timeout for functions when debugging.
+ *
+ * @type {number}
+ */
 const MAX_DEBUG_TIMEOUT = 36000;
+
+/**
+ * Constant for the current directory.
+ *
+ * @type {string}
+ */
 const CURRENT_DIR = '.';
 
+/**
+ * Run functions locally. This class is a wrapper of LocalRuntime, which runs functions
+ * on containers actually.
+ */
 class LocalRunner {
   constructor({
     cwd,
@@ -27,6 +42,13 @@ class LocalRunner {
     this._debugInfo = debugInfo;
   }
 
+  /**
+   * Invoke a function with specified event.
+   *
+   * @param identifier the identifier of the function.
+   * @param event the event which triggers the function.
+   * @returns {Promise.<void>}
+   */
   async invoke(identifier, event) {
     const func = this._getFunction(identifier);
     if (!func) {
@@ -47,6 +69,13 @@ class LocalRunner {
     return !!this._debugInfo.debugPort;
   }
 
+  /**
+   * Return the function metadata from the template.yaml.
+   *
+   * @param identifier the identifier of the function.
+   * @returns {*} the function metadata.
+   * @private
+   */
   _getFunction(identifier) {
     const { functionRes } = findFunctionInTpl(
       identifier.serviceName,
@@ -68,6 +97,13 @@ class LocalRunner {
     });
   }
 
+  /**
+   * Return a function config, which is constructed based on function metadata.
+   *
+   * @param func the metadata of the function.
+   * @returns {FunctionConfig} the function config.
+   * @private
+   */
   _getInvokeConfig(func) {
     const codeAbsPath = this._resolveCodePath(this._cwd, func.codeUri);
     debug(`Resolved absolute path to code: ${codeAbsPath}.`);
@@ -85,6 +121,14 @@ class LocalRunner {
     });
   }
 
+  /**
+   * Resolve code path to be a absolute one.
+   *
+   * @param cwd the current working directory.
+   * @param codeUri the code uri, which can be a local path(relative or absolute), a url, etc.
+   * @returns {*} the absolute path of the code uri.
+   * @private
+   */
   _resolveCodePath(cwd, codeUri) {
     if (!path.isAbsolute(codeUri)) {
       if (!cwd || cwd === CURRENT_DIR) {

--- a/lib/edge/runner.js
+++ b/lib/edge/runner.js
@@ -3,7 +3,7 @@
 'use strict';
 
 const path = require('path');
-const debug = require('debug')('edge:runner');
+const debug = require('debug')('fun:edge:runner');
 
 const { findFunctionInTpl } = require('../definition');
 const Function = require('../function');

--- a/lib/edge/runner.js
+++ b/lib/edge/runner.js
@@ -1,0 +1,100 @@
+/* eslint-disable indent */
+
+'use strict';
+
+const path = require('path');
+const debug = require('debug')('edge:runner');
+
+const { findFunctionInTpl } = require('../definition');
+const Function = require('../function');
+const FunctionConfig = require('./config');
+
+const MAX_DEBUG_TIMEOUT = 36000;
+const CURRENT_DIR = '.';
+
+class LocalRunner {
+  constructor({
+    cwd,
+    runtime,
+    template,
+    profile = {},
+    debugInfo = {},
+  }) {
+    this._cwd = cwd;
+    this._runtime = runtime;
+    this._template = template;
+    this._profile = profile;
+    this._debugInfo = debugInfo;
+  }
+
+  async invoke(identifier, event) {
+    const func = this._getFunction(identifier);
+    if (!func) {
+      console.error(`Error: Cannot find function ${identifier} in template.`);
+      process.exit(-1);
+    }
+    debug(`Found serverless function in template: ${JSON.stringify(func)}`);
+    console.info(`Invoking function ${identifier} (${func.runtime}).`);
+
+    const config = this._getInvokeConfig(func);
+    await this._runtime.invoke(config, event, this._debugInfo);
+  }
+
+  /**
+   * Return whether it runs in debug mode.
+   */
+  isDebugging() {
+    return !!this._debugInfo.debugPort;
+  }
+
+  _getFunction(identifier) {
+    const { functionRes } = findFunctionInTpl(
+      identifier.serviceName,
+      identifier.functionName,
+      this._template
+    );
+    if (!functionRes) {
+      return;
+    }
+    const properties = functionRes['Properties'];
+    return new Function({
+      identifier,
+      handler: properties.Handler,
+      timeout: properties.Timeout,
+      runtime: properties.Runtime,
+      codeUri: properties.CodeUri,
+      memorySize: properties.MemorySize,
+      envVars: properties.EnvironmentVariables,
+    });
+  }
+
+  _getInvokeConfig(func) {
+    const codeAbsPath = this._resolveCodePath(this._cwd, func.codeUri);
+    debug(`Resolved absolute path to code: ${codeAbsPath}.`);
+    const timeout = this.isDebugging() ? MAX_DEBUG_TIMEOUT : func.timeout;
+    return new FunctionConfig({
+      timeout,
+      codeAbsPath,
+      region: this._profile.region,
+      accountId: this._profile.accountId,
+      identifier: func.identifier,
+      handler: func.handler,
+      runtime: func.runtime,
+      memory: func.memorySize,
+      envVars: func.envVars,
+    });
+  }
+
+  _resolveCodePath(cwd, codeUri) {
+    if (!path.isAbsolute(codeUri)) {
+      if (!cwd || cwd === CURRENT_DIR) {
+        cwd = process.cwd();
+      }
+      cwd = path.resolve(cwd);
+      return path.resolve(cwd, codeUri);
+    }
+    return codeUri;
+  }
+}
+
+module.exports = LocalRunner;

--- a/lib/edge/runtime.js
+++ b/lib/edge/runtime.js
@@ -2,7 +2,7 @@
 
 'use strict';
 
-const debug = require('debug')('edge:runtime');
+const debug = require('debug')('fun:edge:runtime');
 const fs = require('fs');
 const path = require('path');
 const util = require('util');

--- a/lib/edge/runtime.js
+++ b/lib/edge/runtime.js
@@ -7,6 +7,7 @@ const fs = require('fs');
 const path = require('path');
 const util = require('util');
 const crypto = require('crypto');
+const crc64 = require("crc64-ecma182.js");
 const Container = require('./container');
 const agent = require('./agent');
 
@@ -74,6 +75,9 @@ class LocalRuntime {
     debug(`Installing code tar archive into ${workingDir} on edge...`);
     await this.container.copy(archive, workingDir);
 
+    const checksum = await this._buildChecksum(archive);
+    debug(`Code checksum is ${checksum}.`);
+
     await this.client.deploy({
       debugPort,
       runtime,
@@ -87,6 +91,7 @@ class LocalRuntime {
       memory: config.memory,
       envVars: config.envVars,
       codeDir: workingDir,
+      codeChecksum: checksum,
       pinned: false,
     });
 
@@ -245,6 +250,21 @@ ${JSON.stringify(vscodeConfigs, null, 4)}
       .update(serviceName || '')
       .update(functionName || '');
     return sha256.digest('hex').substring(0, 32);
+  }
+
+  /**
+   * Build the rcr64 emca182 checksum for the specified file.
+   *
+   * @param path the path of the file
+   * @returns {Promise}
+   * @private
+   */
+  _buildChecksum(path) {
+    return new Promise((resolve, reject) => {
+      crc64.crc64File(path, (err, ret) => {
+        err ? reject(err) : resolve(ret);
+      });
+    });
   }
 
   /**

--- a/lib/edge/runtime.js
+++ b/lib/edge/runtime.js
@@ -13,21 +13,50 @@ const agent = require('./agent');
 const stat = util.promisify(fs.stat);
 const mkdtemp = util.promisify(fs.mkdtemp);
 
-const EDGE_WORKING_DIR_PREFIX = '/tmp/var/run/functions';
-const EDGE_SUPPORTED_RUNTIMES = [
+/**
+ * The prefix of the directory at which the new deployed functions locate.
+ *
+ * @type {string}
+ */
+const WORKING_DIR_PREFIX = '/tmp/var/run/functions';
+
+/**
+ * The runtimes supported by Link IoT Edge.
+ *
+ * @type {[string,string]}
+ */
+const SUPPORTED_RUNTIMES = [
   'nodejs8',
   'python3',
 ];
 
+/**
+ * The class represents a local runtime, which runs the functions code locally and returns
+ * results.
+ */
 class LocalRuntime {
 
+  /**
+   * Construct a new LocalRuntime object.
+   *
+   * @param container a optional container to runs the functions on it.
+   */
   constructor({ container = Container.edge() } = {}) {
     this.container = container;
+    this.client = new agent.FunctionComputeClient();
   }
 
+  /**
+   * Invoke the function with specified event.
+   *
+   * @param config the config of the function that's invoked.
+   * @param event the event that triggers the function.
+   * @param debugInfo the info about debugging mode.
+   * @returns {Promise.<void>}
+   */
   async invoke(config, event, debugInfo = {}) {
     const runtime = config.runtime;
-    if (!EDGE_SUPPORTED_RUNTIMES.includes(runtime)) {
+    if (!SUPPORTED_RUNTIMES.includes(runtime)) {
       throw new Error(`Unsupported function runtime ${runtime}.`);
     }
 
@@ -41,13 +70,11 @@ class LocalRuntime {
     debug(`Code archive tarred at ${archive}.`);
     // Constructing a path matches the target OS.
     const workingDir =
-      `${EDGE_WORKING_DIR_PREFIX}/${identifier.serviceName}/${identifier.functionName}`;
+      `${WORKING_DIR_PREFIX}/${identifier.serviceName}/${identifier.functionName}`;
     debug(`Installing code tar archive into ${workingDir} on edge...`);
     await this.container.copy(archive, workingDir);
 
-    // FunctionCompute should be constructed after the container starts.
-    const functionCompute = new agent.FunctionCompute();
-    await functionCompute.deploy({
+    await this.client.deploy({
       debugPort,
       runtime,
       functionId,
@@ -71,7 +98,7 @@ class LocalRuntime {
     let timer;
     try {
       debug(`Invoking function ${functionId} with ${event}.`);
-      const invocation = functionCompute.invoke({
+      const invocation = this.client.invoke({
         functionId,
         event,
       });
@@ -80,13 +107,24 @@ class LocalRuntime {
       const result = await invocation;
       console.log(result.toString());
     } catch (err) {
-      console.log(err);
-    }
-    if (timer) {
-      clearTimeout(timer);
+      // We catch the error here just for do some cleaning. So rethrow it.
+      throw err;
+    } finally {
+      if (timer) {
+        clearTimeout(timer);
+      }
     }
   }
 
+  /**
+   * Configure what can interrupt the execution of the function.
+   *
+   * @param identifier the identifier of the function.
+   * @param timeout the timeout for the execution of the function.
+   * @param isDebugging whether the execution is in debugging mode.
+   * @returns {*} a timer to cancel the timeout interruption.
+   * @private
+   */
   _configureInterrupt(identifier, timeout, isDebugging) {
     let timer;
     const timeoutHandler = () => {
@@ -110,6 +148,16 @@ class LocalRuntime {
     return timer;
   }
 
+  /**
+   * Return the configurations for debuggers, currently only vscode.
+   *
+   * @param runtime the runtime of the function.
+   * @param hostDir the local path of the function code.
+   * @param workingDir the remote path on the container where the function locates.
+   * @param debugPort the debug port for debugger to connect.
+   * @returns {string} the configurations for debuggers.
+   * @private
+   */
   _getDebuggerConfigs(runtime, hostDir, workingDir, debugPort) {
     let vscodeConfigs;
     switch (runtime) {
@@ -162,6 +210,13 @@ ${JSON.stringify(vscodeConfigs, null, 4)}
     return configs;
   }
 
+  /**
+   * Return the parent directory of the code.
+   *
+   * @param codePath the path of the code.
+   * @returns {Promise.<*>}
+   * @private
+   */
   async _getCodeDir(codePath) {
     const stats = await stat(codePath);
     if (stats.isFile()) {
@@ -170,6 +225,16 @@ ${JSON.stringify(vscodeConfigs, null, 4)}
     return codePath;
   }
 
+  /**
+   * Build the function id. It's immutable for same config.
+   *
+   * @param region the region, for example cn-hangzhou.
+   * @param accountId the id of the account.
+   * @param serviceName the service name to which the function belongs.
+   * @param functionName the name of the function.
+   * @returns {string} the id for the function.
+   * @private
+   */
   _buildIdString(region, accountId, serviceName, functionName) {
     // We need a uuid here in fact. But in order to keep the function id fixed,
     // we use a sha256 id instead.
@@ -182,6 +247,13 @@ ${JSON.stringify(vscodeConfigs, null, 4)}
     return sha256.digest('hex').substring(0, 32);
   }
 
+  /**
+   * Tar the code into a file. Return the path of the tar file.
+   *
+   * @param codeDir the directory of the code, which is a absolute one.
+   * @returns {Promise} the promise to get the path of the tar file.
+   * @private
+   */
   static async _getCodeArchive(codeDir) {
     const stats = await stat(codeDir);
     if (stats.isDirectory()) {

--- a/lib/edge/runtime.js
+++ b/lib/edge/runtime.js
@@ -1,0 +1,214 @@
+/* eslint-disable quotes */
+
+'use strict';
+
+const debug = require('debug')('edge:runtime');
+const fs = require('fs');
+const path = require('path');
+const util = require('util');
+const crypto = require('crypto');
+const Container = require('./container');
+const agent = require('./agent');
+
+const stat = util.promisify(fs.stat);
+const mkdtemp = util.promisify(fs.mkdtemp);
+
+const EDGE_WORKING_DIR_PREFIX = '/tmp/var/run/functions';
+const EDGE_SUPPORTED_RUNTIMES = [
+  'nodejs8',
+  'python3',
+];
+
+class LocalRuntime {
+
+  constructor({ container = Container.edge() } = {}) {
+    this.container = container;
+  }
+
+  async invoke(config, event, debugInfo = {}) {
+    const runtime = config.runtime;
+    if (!EDGE_SUPPORTED_RUNTIMES.includes(runtime)) {
+      throw new Error(`Unsupported function runtime ${runtime}.`);
+    }
+
+    const debugPort = debugInfo.debugPort;
+    const identifier = config.identifier;
+    const functionId = this._buildIdString(config.region, config.accountId,
+      config.serviceName, config.functionName);
+    debug(`Build function id ${functionId}`);
+    const codeDir = await this._getCodeDir(config.codeAbsPath);
+    const archive = await LocalRuntime._getCodeArchive(codeDir);
+    debug(`Code archive tarred at ${archive}.`);
+    // Constructing a path matches the target OS.
+    const workingDir =
+      `${EDGE_WORKING_DIR_PREFIX}/${identifier.serviceName}/${identifier.functionName}`;
+    debug(`Installing code tar archive into ${workingDir} on edge...`);
+    await this.container.copy(archive, workingDir);
+
+    // FunctionCompute should be constructed after the container starts.
+    const functionCompute = new agent.FunctionCompute();
+    await functionCompute.deploy({
+      debugPort,
+      runtime,
+      functionId,
+      region: config.region,
+      accountId: config.accountId,
+      serviceName: identifier.serviceName,
+      functionName: identifier.functionName,
+      handler: config.handler,
+      timeout: config.timeout,
+      memory: config.memory,
+      envVars: config.envVars,
+      codeDir: workingDir,
+      pinned: false,
+    });
+
+    if (debugPort && debugInfo.outputDebuggerConfigs) {
+      const configs = this._getDebuggerConfigs(config.runtime, codeDir, workingDir, debugPort);
+      console.log(configs);
+    }
+
+    let timer;
+    try {
+      debug(`Invoking function ${functionId} with ${event}.`);
+      const invocation = functionCompute.invoke({
+        functionId,
+        event,
+      });
+      const timeout = config.timeout;
+      timer = this._configureInterrupt(identifier, timeout, !!debugPort);
+      const result = await invocation;
+      console.log(result.toString());
+    } catch (err) {
+      console.log(err);
+    }
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
+
+  _configureInterrupt(identifier, timeout, isDebugging) {
+    let timer;
+    const timeoutHandler = () => {
+      console.info(`Function ${identifier} timed out after ${timeout} seconds.`);
+      // FIXME Whether should we stop or remove the function at edge?
+      process.exit(-1);
+    };
+    const signalHandler = (signal) => {
+      console.info(`Execution of function ${identifier} was interrupted.`);
+      if (timer) {
+        clearTimeout(timer);
+      }
+      // FIXME Whether should we stop or remove the function at edge?
+      process.exit(-1);
+    };
+    if (!isDebugging) {
+      timer = setTimeout(timeoutHandler, timeout * 1000);
+    }
+    process.on('SIGINT', signalHandler);
+    process.on('SIGTERM', signalHandler);
+    return timer;
+  }
+
+  _getDebuggerConfigs(runtime, hostDir, workingDir, debugPort) {
+    let vscodeConfigs;
+    switch (runtime) {
+    case 'nodejs8':
+      vscodeConfigs = {
+        'version': '0.2.0',
+        'configurations': [
+          {
+            'name': 'Attach to Fun (Node.js 8)',
+            'type': 'node',
+            'request': 'attach',
+            'address': 'localhost',
+            'port': debugPort,
+            'localRoot': `${hostDir}`,
+            'remoteRoot': `${workingDir}`,
+            'protocol': 'inspector',
+            'stopOnEntry': false
+          }
+        ]
+      };
+      break;
+    case 'python3':
+      vscodeConfigs = {
+        'version': '0.2.0',
+        'configurations': [
+          {
+            'name': 'Attach to Fun (Python 3)',
+            'type': 'python',
+            'request': 'attach',
+            'host': 'localhost',
+            'port': debugPort,
+            'pathMappings': [
+              {
+                'localRoot': `${hostDir}`,
+                'remoteRoot': `${workingDir}`,
+              }
+            ]
+          }
+        ]
+      };
+      break;
+    default:
+      break;
+    }
+    const configs = `
+Debugging Configurations
+## VS Code ##
+${JSON.stringify(vscodeConfigs, null, 4)}
+`;
+    return configs;
+  }
+
+  async _getCodeDir(codePath) {
+    const stats = await stat(codePath);
+    if (stats.isFile()) {
+      return path.dirname(codePath);
+    }
+    return codePath;
+  }
+
+  _buildIdString(region, accountId, serviceName, functionName) {
+    // We need a uuid here in fact. But in order to keep the function id fixed,
+    // we use a sha256 id instead.
+    const sha256 = crypto.createHash('sha256');
+    sha256
+      .update(region || '')
+      .update(accountId || '')
+      .update(serviceName || '')
+      .update(functionName || '');
+    return sha256.digest('hex').substring(0, 32);
+  }
+
+  static async _getCodeArchive(codeDir) {
+    const stats = await stat(codeDir);
+    if (stats.isDirectory()) {
+      const os = require('os');
+      const path = require('path');
+      const basename = path.basename(codeDir);
+      const tmpdir = await mkdtemp(path.join(os.tmpdir(), '/'));
+      const tarfile = path.join(tmpdir, `${basename}.tar`);
+
+      return new Promise((resolve, reject) => {
+        const output = fs.createWriteStream(tarfile, { encoding: 'utf-8', });
+        output.on('close', () => {
+          resolve(tarfile);
+        });
+
+        const archive = require('archiver')('tar');
+        archive.on('error', (err) => {
+          console.error('Taring code archive failed: %s', codeDir);
+          reject(err);
+        });
+        archive.pipe(output);
+        archive.directory(codeDir, '');
+        archive.finalize();
+      });
+    }
+    throw new Error(`Not a directory at ${codeDir}.`);
+  }
+}
+
+module.exports = LocalRuntime;

--- a/lib/exception-handler.js
+++ b/lib/exception-handler.js
@@ -1,10 +1,14 @@
 'use strict';
 
+const debug = require('debug');
+
 const handler = function (err) {
-  if (err.stack) {
+  // If the verbose option is true, in addition to the message,
+  // print the stack of the error.
+  if (debug.enabled('*') && err.stack) {
     console.error(err.stack);
   } else {
-    console.error(err);
+    console.error(err.message);
   }
   process.exit(-1);
 };

--- a/lib/function-identifier.js
+++ b/lib/function-identifier.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const FUNCTION_ID_PATTEN = /(([a-zA-Z_][\w-]{0,127})\/)?([a-zA-Z_][\w-]{0,127})$/;
+const SERVICE_NAME_REGEX_INDEX = 2;
+const FUNCTION_NAME_REGEX_INDEX = 3;
+
+class FunctionIdentifier {
+  constructor(identifier) {
+    const results = identifier.match(FUNCTION_ID_PATTEN);
+    if (!results) {
+      throw new Error(
+        `Can't parse the given string as a function identifier: ${identifier}.`
+      );
+    }
+    this._identifier = identifier;
+    this._serviceName = results[SERVICE_NAME_REGEX_INDEX];
+    this._functionName = results[FUNCTION_NAME_REGEX_INDEX];
+  }
+
+  get identifier() {
+    return this._identifier;
+  }
+
+  get serviceName() {
+    return this._serviceName;
+  }
+
+  get functionName() {
+    return this._functionName;
+  }
+
+  toString() {
+    return this._identifier;
+  }
+}
+
+module.exports = FunctionIdentifier;

--- a/lib/function.js
+++ b/lib/function.js
@@ -1,0 +1,29 @@
+/* eslint-disable indent */
+
+'use strict';
+
+class Function {
+  constructor({
+    identifier,
+    handler,
+    runtime,
+    timeout,
+    codeUri,
+    memorySize,
+    envVars,
+    initializer = undefined,
+    initializationTimeout = undefined,
+  }) {
+    this.identifier = identifier;
+    this.handler = handler;
+    this.runtime = runtime;
+    this.timeout = timeout;
+    this.codeUri = codeUri;
+    this.memorySize = memorySize;
+    this.envVars = envVars;
+    this.initializer = initializer;
+    this.initializationTimeout = initializationTimeout;
+  }
+}
+
+module.exports = Function;

--- a/lib/local/function.js
+++ b/lib/local/function.js
@@ -1,0 +1,56 @@
+'use strict';
+
+const docker = require('../docker');
+
+const debug = require('debug')('fun:local');
+
+async function invokeFunction(serviceName, functionName, functionRes, debugPort, event, debugIde, httpParams, outputStream, errorStream, nasConfig, tplPath, httpMode) {
+  const functionProps = functionRes.Properties;
+  
+  const runtime = functionProps.Runtime;
+  const codeUri = functionProps.CodeUri;
+  
+  debug(`runtime: ${runtime}`);
+  debug(`codeUri: ${codeUri}`);
+  
+  const mounts = [];
+  
+  const codeMount = await docker.resolveCodeUriToMount(codeUri);
+  
+  mounts.push(codeMount);
+  
+  const nasMount = await docker.resolveNasConfigToMount(nasConfig, tplPath);
+  
+  const dockerUser = await docker.resolveDockerUser(nasConfig);
+  
+  if (nasMount) {
+    mounts.push(nasMount);
+  }
+  
+  debug(`docker mounts: %s`, JSON.stringify(mounts, null, 4));
+  debug('debug port: %d', debugPort);
+  
+  const imageName = docker.resolveRuntimeToDockerImage(runtime);
+  
+  await docker.pullImageIfNeed(imageName);
+  
+  if (debugPort && debugIde) {
+    await docker.showDebugIdeTips(serviceName, functionName, runtime, codeMount.Source, debugPort);
+  }
+  
+  const containerName = docker.generateRamdomContainerName();
+  
+  const envs = await docker.generateDockerEnvs(functionProps, debugPort, httpParams);
+  
+  const cmd = docker.generateDockerCmd(functionProps, httpMode);
+    
+  const opts = await docker.generateDockerOpts(runtime, containerName, mounts, cmd, debugPort, envs, dockerUser);
+  
+  debug('docker opts: %j', opts);
+  
+  await docker.run(opts, containerName, event, outputStream, errorStream);
+}
+
+module.exports = {
+  invokeFunction
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -220,7 +220,7 @@
     },
     "ansi-escapes": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
       "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw=="
     },
     "ansi-regex": {
@@ -633,7 +633,7 @@
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha1-MnE7wCj3XAL9txDXx7zsHyxgcO8="
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
     },
     "bufferview": {
       "version": "1.0.1",
@@ -760,7 +760,7 @@
     "chownr": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
-      "integrity": "sha1-VHJri4//TfBTxCGH6AH7RBLfFJQ="
+      "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g=="
     },
     "circular-json": {
       "version": "0.3.3",
@@ -824,7 +824,7 @@
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "resolved": "http://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "requires": {
             "code-point-at": "^1.0.0",
@@ -1155,7 +1155,7 @@
     "docker-modem": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-1.0.7.tgz",
-      "integrity": "sha1-aXAqlcBg7rZ3X3nM3Mc05ZRpcqQ=",
+      "integrity": "sha512-PdcMwnPXgO4sN4BU+XPTjX6Ak4ZnoBwMKp+8DkDn477N/zQhk5jE1QiSAVpTn4j2TfPR5A6voVp8d5wa58iKEA==",
       "requires": {
         "JSONStream": "1.3.2",
         "debug": "^3.2.5",
@@ -1166,7 +1166,7 @@
         "debug": {
           "version": "3.2.6",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha1-6D0X3hbYp++3cX7b5fsQE17uYps=",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "requires": {
             "ms": "^2.1.1"
           }
@@ -1194,7 +1194,7 @@
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         }
       }
@@ -1272,7 +1272,7 @@
     },
     "es6-promise": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz",
       "integrity": "sha1-AQ1YWEI6XxGJeWZfRkhqlcbuK7Y="
     },
     "escape-html": {
@@ -1666,7 +1666,7 @@
     },
     "external-editor": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
       "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
       "dev": true,
       "requires": {
@@ -1956,7 +1956,7 @@
     },
     "get-stream": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
     },
     "get-value": {
@@ -2233,7 +2233,7 @@
     },
     "inquirer": {
       "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-5.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/inquirer/-/inquirer-5.2.0.tgz",
       "integrity": "sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==",
       "requires": {
         "ansi-escapes": "^3.0.0",
@@ -2693,12 +2693,12 @@
       "dependencies": {
         "core-js": {
           "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.3.0.tgz",
+          "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.3.0.tgz",
           "integrity": "sha1-+rg/uwstjchfpjbEudNMdUIMbWU="
         },
         "readable-stream": {
           "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
           "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -2711,7 +2711,7 @@
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         }
       }
@@ -2921,7 +2921,7 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "mixin-deep": {
@@ -3284,7 +3284,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "p-finally": {
@@ -3322,7 +3322,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-is-inside": {
@@ -3689,7 +3689,7 @@
     "pump": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
-      "integrity": "sha1-Xf6DEcM7v2/BgmH580cCxHwIqVQ=",
+      "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
       "requires": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -4048,6 +4048,34 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
+    "single-line-log": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/single-line-log/-/single-line-log-1.1.2.tgz",
+      "integrity": "sha1-wvg/Jzo+GhbtsJlWYdoO1e8DM2Q=",
+      "requires": {
+        "string-width": "^1.0.1"
+      },
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        }
+      }
+    },
     "sinon": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-5.1.1.tgz",
@@ -4265,7 +4293,7 @@
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "sshpk": {
@@ -4368,7 +4396,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
     "strip-json-comments": {
@@ -4427,7 +4455,7 @@
     "tar-fs": {
       "version": "1.16.3",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.3.tgz",
-      "integrity": "sha1-lmpiiEHaLEAQQGqCFny9Xgxy1Qk=",
+      "integrity": "sha512-NvCeXpYx7OsmOh8zIOP/ebG55zZmxLE0etfWRbWok+q2Qo8x/vOR/IJT1taADXPe+jsiu9axDb3X4B+iIgNlKw==",
       "requires": {
         "chownr": "^1.0.1",
         "mkdirp": "^0.5.1",
@@ -4466,7 +4494,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "tmp": {
@@ -4782,7 +4810,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
         "string-width": "^1.0.1",
@@ -4799,7 +4827,7 @@
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "resolved": "http://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "requires": {
             "code-point-at": "^1.0.0",
@@ -4834,7 +4862,7 @@
     },
     "xmlbuilder": {
       "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "resolved": "http://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
       "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
     },
     "xtend": {
@@ -4854,7 +4882,7 @@
     },
     "yargs": {
       "version": "3.32.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+      "resolved": "http://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
       "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
       "requires": {
         "camelcase": "^2.0.1",
@@ -4876,7 +4904,7 @@
         },
         "os-locale": {
           "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+          "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
           "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
           "requires": {
             "lcid": "^1.0.0"
@@ -4884,7 +4912,7 @@
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "resolved": "http://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "requires": {
             "code-point-at": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -980,6 +980,11 @@
         "readable-stream": "^2.0.0"
       }
     },
+    "crc64-ecma182.js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/crc64-ecma182.js/-/crc64-ecma182.js-1.0.0.tgz",
+      "integrity": "sha1-C/c78lhbWcaH+Fdz55kd9y11n3o="
+    },
     "cross-spawn": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -824,7 +824,7 @@
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": "http://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "requires": {
             "code-point-at": "^1.0.0",
@@ -1671,7 +1671,7 @@
     },
     "external-editor": {
       "version": "2.2.0",
-      "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
       "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
       "dev": true,
       "requires": {
@@ -1834,7 +1834,7 @@
     },
     "finalhandler": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
       "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
       "requires": {
         "debug": "2.6.9",
@@ -1961,7 +1961,7 @@
     },
     "get-stream": {
       "version": "3.0.0",
-      "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
     },
     "get-value": {
@@ -2157,7 +2157,7 @@
     },
     "http-errors": {
       "version": "1.6.3",
-      "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "requires": {
         "depd": "~1.1.2",
@@ -2238,7 +2238,7 @@
     },
     "inquirer": {
       "version": "5.2.0",
-      "resolved": "http://registry.npmjs.org/inquirer/-/inquirer-5.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-5.2.0.tgz",
       "integrity": "sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==",
       "requires": {
         "ansi-escapes": "^3.0.0",
@@ -2814,7 +2814,7 @@
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
     "mem": {
@@ -2840,7 +2840,7 @@
         },
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -2851,7 +2851,7 @@
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         }
       }
@@ -2926,7 +2926,7 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "mixin-deep": {
@@ -3289,7 +3289,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "p-finally": {
@@ -3327,7 +3327,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-is-inside": {
@@ -4298,7 +4298,7 @@
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "resolved": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "sshpk": {
@@ -4401,7 +4401,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
     "strip-json-comments": {
@@ -4499,7 +4499,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "tmp": {
@@ -4815,7 +4815,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
         "string-width": "^1.0.1",
@@ -4832,7 +4832,7 @@
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": "http://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "requires": {
             "code-point-at": "^1.0.0",
@@ -4867,7 +4867,7 @@
     },
     "xmlbuilder": {
       "version": "9.0.7",
-      "resolved": "http://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
       "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
     },
     "xtend": {
@@ -4887,7 +4887,7 @@
     },
     "yargs": {
       "version": "3.32.0",
-      "resolved": "http://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
       "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
       "requires": {
         "camelcase": "^2.0.1",
@@ -4909,7 +4909,7 @@
         },
         "os-locale": {
           "version": "1.4.0",
-          "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
           "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
           "requires": {
             "lcid": "^1.0.0"
@@ -4917,7 +4917,7 @@
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": "http://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "requires": {
             "code-point-at": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "colors": "^1.1.2",
     "command-exists": "^1.2.8",
     "commander": "^2.15.1",
+    "crc64-ecma182.js": "^1.0.0",
     "debug": "^2.6.8",
     "dev-null": "^0.1.1",
     "dockerode": "^2.5.7",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "require-from-string": "^2.0.2",
     "rimraf": "^2.6.2",
     "semver": "^5.5.0",
+    "single-line-log": "^1.1.2",
     "tablestore": "^4.3.0",
     "urlencode": "^1.1.0"
   },

--- a/test/edge/agent.test.js
+++ b/test/edge/agent.test.js
@@ -1,0 +1,431 @@
+'use strict';
+
+const expect = require('expect.js');
+const sinon = require('sinon');
+
+const https = require('https');
+const EventEmitter = require('events');
+const agent = require('../../lib/edge/agent');
+
+const TEST_DEPLOY_FUNCTION = {
+  functionId: 'function_id',
+  serviceName: 'service_name',
+  functionName: 'function_name',
+  handler: 'index.handler',
+  runtime: 'nodejs8',
+  timeout: 3,
+  memory: 128,
+  codeDir: '/tmp/',
+  accountId: 'account_id',
+  region: 'cn-hangzhou',
+  pinned: true,
+  envVars: {
+    TEST_ENVIRONMENT: 'test_environment',
+  },
+  debugPort: 5700,
+};
+
+const TEST_INVOKE_FUNCTION = {
+  functionId: 'function_id',
+  serviceName: 'service_name',
+  functionName: 'function_name',
+  accountId: 'account_id',
+  region: 'cn-hangzhou',
+  event: '{}',
+};
+
+class ClientRequest extends EventEmitter {
+  write() {}
+  end() {}
+}
+
+const cookie = 'd3f19b4c9218f4fac6ead23554fd8aa4ba0d08a3';
+class ServerResponse extends EventEmitter {
+  constructor() {
+    super();
+    this.headers = {
+      'set-cookie': cookie,
+    };
+  }
+}
+
+describe('edge/FunctionComputeClient', function () {
+  let httpsRequest;
+  beforeEach(function () {
+    httpsRequest = sinon.stub(https, 'request');
+  });
+  afterEach(function () {
+    httpsRequest.restore();
+  });
+  describe('#login', function () {
+    it('should throw since request writing error', async function () {
+      const clientRequest = new ClientRequest();
+      const write = sinon.stub(clientRequest, 'write').callsFake(function () {
+        clientRequest.emit('error', new Error('Cannot write'));
+      });
+      httpsRequest.callsFake(function (options, callback) {
+        return clientRequest;
+      });
+      const client = new agent.FunctionComputeClient();
+      let error;
+      try {
+        await client.login();
+      } catch (err) {
+        error = err;
+      }
+      expect(error).to.be.an(Error);
+      write.restore();
+    });
+
+    it('should throw since server internal error', async function () {
+      let cb;
+      const serverResponse = new ServerResponse();
+      const clientRequest = new ClientRequest();
+      const end = sinon.stub(clientRequest, 'end').callsFake(function () {
+        cb(serverResponse);
+        serverResponse.emit('data', '');
+        serverResponse.emit('end');
+      });
+      httpsRequest.callsFake(function (options, callback) {
+        cb = callback;
+        return clientRequest;
+      });
+      const client = new agent.FunctionComputeClient();
+      let error;
+      try {
+        await client.login();
+      } catch (err) {
+        error = err;
+      }
+      expect(error).to.be.an(Error);
+      end.restore();
+    });
+    it('should throw since authentication fails', async function () {
+      let cb;
+      const serverResponse = new ServerResponse();
+      const clientRequest = new ClientRequest();
+      const end = sinon.stub(clientRequest, 'end').callsFake(function () {
+        cb(serverResponse);
+        serverResponse.emit('data', JSON.stringify({
+          code: 400,
+          message: 'User name or password incorrect'
+        }));
+        serverResponse.emit('end');
+      });
+      httpsRequest.callsFake(function (options, callback) {
+        cb = callback;
+        return clientRequest;
+      });
+      const client = new agent.FunctionComputeClient();
+      let error;
+      try {
+        await client.login();
+      } catch (err) {
+        error = err;
+      }
+      expect(error).to.be.an(Error);
+      end.restore();
+    });
+    it('should pass since all requirements meet', async function () {
+      let cb;
+      const serverResponse = new ServerResponse();
+      const clientRequest = new ClientRequest();
+      const end = sinon.stub(clientRequest, 'end').callsFake(function () {
+        cb(serverResponse);
+        serverResponse.emit('data', JSON.stringify({
+          code: 200,
+        }));
+        serverResponse.emit('end');
+      });
+      httpsRequest.callsFake(function (options, callback) {
+        cb = callback;
+        return clientRequest;
+      });
+      const client = new agent.FunctionComputeClient();
+      let error;
+      try {
+        await client.login();
+      } catch (err) {
+        error = err;
+      }
+      expect(error).to.not.be.an(Error);
+      end.restore();
+
+    });
+  });
+  describe('#deploy', function () {
+    it('should throw since neither Function id nor serviceName/functionName is provided', async function () {
+      const info = Object({}, TEST_DEPLOY_FUNCTION, {
+        functionId: undefined,
+        serviceName: undefined,
+        functionName: undefined,
+      });
+      const client = new agent.FunctionComputeClient();
+      let error;
+      try {
+        await client.deploy(info);
+      } catch (err) {
+        error = err;
+      }
+      expect(error).to.be.an(Error);
+    });
+    it('should throw since login fails', async function () {
+      const client = new agent.FunctionComputeClient();
+      const login = sinon.stub(client, 'login').rejects(new Error('Cannot login'));
+      let error;
+      try {
+        await client.deploy(TEST_DEPLOY_FUNCTION);
+      } catch (err) {
+        error = err;
+      }
+      expect(error).to.be.an(Error);
+      login.restore();
+    });
+    it('should throw since request writing error', async function () {
+      const clientRequest = new ClientRequest();
+      const write = sinon.stub(clientRequest, 'write').callsFake(function () {
+        clientRequest.emit('error', new Error('Cannot write'));
+      });
+      httpsRequest.callsFake(function (options, callback) {
+        return clientRequest;
+      });
+      const client = new agent.FunctionComputeClient();
+      const login = sinon.stub(client, 'login').resolves(cookie);
+      let error;
+      try {
+        await client.deploy(TEST_DEPLOY_FUNCTION);
+      } catch (err) {
+        error = err;
+      }
+      expect(error).to.be.an(Error);
+      login.restore();
+      write.restore();
+    });
+    it('should throw since server internal error', async function () {
+      let cb;
+      const serverResponse = new ServerResponse();
+      const clientRequest = new ClientRequest();
+      const end = sinon.stub(clientRequest, 'end').callsFake(function () {
+        cb(serverResponse);
+        serverResponse.emit('data', '');
+        serverResponse.emit('end');
+      });
+      httpsRequest.callsFake(function (options, callback) {
+        cb = callback;
+        return clientRequest;
+      });
+      const client = new agent.FunctionComputeClient();
+      const login = sinon.stub(client, 'login').resolves(cookie);
+      let error;
+      try {
+        await client.deploy(TEST_DEPLOY_FUNCTION);
+      } catch (err) {
+        error = err;
+      }
+      expect(error).to.be.an(Error);
+      login.restore();
+      end.restore();
+    });
+    it('should throw since memory size error', async function () {
+      let cb;
+      const serverResponse = new ServerResponse();
+      const clientRequest = new ClientRequest();
+      const end = sinon.stub(clientRequest, 'end').callsFake(function () {
+        cb(serverResponse);
+        serverResponse.emit('data', JSON.stringify({
+          code: 400,
+          message: 'Memory size is not a number'
+        }));
+        serverResponse.emit('end');
+      });
+      httpsRequest.callsFake(function (options, callback) {
+        cb = callback;
+        return clientRequest;
+      });
+      const client = new agent.FunctionComputeClient();
+      const login = sinon.stub(client, 'login').resolves(cookie);
+      const info = Object.assign({}, TEST_DEPLOY_FUNCTION, {
+        memory: '128',
+      });
+      let error;
+      try {
+        await client.deploy(info);
+      } catch (err) {
+        error = err;
+      }
+      expect(error).to.be.an(Error);
+      login.restore();
+      end.restore();
+    });
+    it('should pass since all requirements meet', async function () {
+      let cb;
+      const serverResponse = new ServerResponse();
+      const clientRequest = new ClientRequest();
+      const end = sinon.stub(clientRequest, 'end').callsFake(function () {
+        cb(serverResponse);
+        serverResponse.emit('data', JSON.stringify({
+          code: 200,
+        }));
+        serverResponse.emit('end');
+      });
+      httpsRequest.callsFake(function (options, callback) {
+        cb = callback;
+        return clientRequest;
+      });
+      const client = new agent.FunctionComputeClient();
+      const login = sinon.stub(client, 'login').resolves(cookie);
+      let error;
+      try {
+        await client.deploy(TEST_DEPLOY_FUNCTION);
+      } catch (err) {
+        error = err;
+      }
+      expect(error).to.not.be.an(Error);
+      login.restore();
+      end.restore();
+    });
+  });
+  describe('#invoke', function () {
+    it('should throw since neither Function id nor serviceName/functionName is provided', async function () {
+      const info = {
+        accountId: TEST_DEPLOY_FUNCTION.accountId,
+        region: TEST_DEPLOY_FUNCTION.region,
+      };
+      const client = new agent.FunctionComputeClient();
+      let error;
+      try {
+        await client.invoke(info);
+      } catch (err) {
+        error = err;
+      }
+      expect(error).to.be.an(Error);
+    });
+    it('should throw since invocation type is neither Sync nor Async', async function () {
+      const info = Object.assign({}, TEST_INVOKE_FUNCTION, {
+        invocationType: 'Test'
+      });
+      const client = new agent.FunctionComputeClient();
+      let error;
+      try {
+        await client.invoke(info);
+      } catch (err) {
+        error = err;
+      }
+      expect(error).to.be.an(Error);
+    });
+    it('should throw since login fails', async function () {
+      const client = new agent.FunctionComputeClient();
+      const login = sinon.stub(client, 'login').rejects(new Error('Cannot login'));
+      let error;
+      try {
+        await client.invoke(TEST_INVOKE_FUNCTION);
+      } catch (err) {
+        error = err;
+      }
+      expect(error).to.be.an(Error);
+      login.restore();
+    });
+    it('should throw since request writing error', async function () {
+      const clientRequest = new ClientRequest();
+      const write = sinon.stub(clientRequest, 'write').callsFake(function () {
+        clientRequest.emit('error', new Error('Cannot write'));
+      });
+      httpsRequest.callsFake(function (options, callback) {
+        return clientRequest;
+      });
+      const client = new agent.FunctionComputeClient();
+      const login = sinon.stub(client, 'login').resolves(cookie);
+      let error;
+      try {
+        await client.invoke(TEST_INVOKE_FUNCTION);
+      } catch (err) {
+        error = err;
+      }
+      expect(error).to.be.an(Error);
+      login.restore();
+      write.restore();
+    });
+    it('should throw since server internal error', async function () {
+      let cb;
+      const serverResponse = new ServerResponse();
+      const clientRequest = new ClientRequest();
+      const end = sinon.stub(clientRequest, 'end').callsFake(function () {
+        cb(serverResponse);
+        serverResponse.emit('data', '');
+        serverResponse.emit('end');
+      });
+      httpsRequest.callsFake(function (options, callback) {
+        cb = callback;
+        return clientRequest;
+      });
+      const client = new agent.FunctionComputeClient();
+      const login = sinon.stub(client, 'login').resolves(cookie);
+      let error;
+      try {
+        await client.invoke(TEST_INVOKE_FUNCTION);
+      } catch (err) {
+        error = err;
+      }
+      expect(error).to.be.an(Error);
+      login.restore();
+      end.restore();
+    });
+    it('should throw since function not found error', async function () {
+      let cb;
+      const serverResponse = new ServerResponse();
+      const clientRequest = new ClientRequest();
+      const end = sinon.stub(clientRequest, 'end').callsFake(function () {
+        cb(serverResponse);
+        serverResponse.emit('data', JSON.stringify({
+          code: 400,
+          message: 'Function not found'
+        }));
+        serverResponse.emit('end');
+      });
+      httpsRequest.callsFake(function (options, callback) {
+        cb = callback;
+        return clientRequest;
+      });
+      const client = new agent.FunctionComputeClient();
+      const login = sinon.stub(client, 'login').resolves(cookie);
+      let error;
+      try {
+        await client.invoke(TEST_INVOKE_FUNCTION);
+      } catch (err) {
+        error = err;
+      }
+      expect(error).to.be.an(Error);
+      login.restore();
+      end.restore();
+    });
+    it('should pass since all requirements meet', async function () {
+      let cb;
+      const serverResponse = new ServerResponse();
+      const clientRequest = new ClientRequest();
+      const end = sinon.stub(clientRequest, 'end').callsFake(function () {
+        cb(serverResponse);
+        serverResponse.emit('data', JSON.stringify({
+          code: 200,
+          data: Buffer.from('result').toString('base64'),
+        }));
+        serverResponse.emit('end');
+      });
+      httpsRequest.callsFake(function (options, callback) {
+        cb = callback;
+        return clientRequest;
+      });
+      const client = new agent.FunctionComputeClient();
+      const login = sinon.stub(client, 'login').resolves(cookie);
+      let error;
+      try {
+        await client.invoke(TEST_INVOKE_FUNCTION);
+      } catch (err) {
+        error = err;
+      }
+      console.log(error);
+      expect(error).to.not.be.an(Error);
+      login.restore();
+      end.restore();
+    });
+  });
+});

--- a/test/edge/agent.test.js
+++ b/test/edge/agent.test.js
@@ -1,3 +1,5 @@
+/* eslint-disable callback-return */
+
 'use strict';
 
 const expect = require('expect.js');

--- a/test/edge/container.test.js
+++ b/test/edge/container.test.js
@@ -1,0 +1,426 @@
+'use strict';
+
+const expect = require('expect.js');
+const sinon = require('sinon');
+const Docker = require('dockerode');
+const inquirer = require('inquirer');
+const Container = require('../../lib/edge/container');
+
+const TEST_CONTAINER_ID = 'd852359721fe';
+const TEST_COPY_SOURCE_TAR = '/tmp/source/test.tar';
+const TEST_COPY_TARGET_DIR = '/tmp/target/';
+
+describe('edge/Container', function () {
+  describe('#isCreated', function () {
+    let listContainers;
+    let docker;
+    beforeEach(function () {
+      docker = new Docker();
+      listContainers = sinon.stub(docker, 'listContainers');
+    });
+    afterEach(function () {
+      listContainers.restore();
+      docker = undefined;
+    });
+    it('should return false since cannot find a existing container', async function () {
+      listContainers.resolves([]);
+      const container = Container.edge(docker);
+      await container.bind();
+      expect(container.isCreated()).to.not.be.ok();
+    });
+    it('should return true since find a existing container', async function () {
+      listContainers.resolves([{
+        Id: TEST_CONTAINER_ID,
+      }]);
+      const container = Container.edge(docker);
+      await container.bind();
+      expect(container.isCreated()).to.be.ok();
+    });
+  });
+  describe('#isRunning', function () {
+    let listContainers;
+    let docker;
+    beforeEach(function () {
+      docker = new Docker();
+      listContainers = sinon.stub(docker, 'listContainers');
+    });
+    afterEach(function () {
+      listContainers.restore();
+      docker = undefined;
+    });
+    it('should return false since the container is not running', async function () {
+      listContainers.resolves([{
+        Id: TEST_CONTAINER_ID,
+        State: 'exited',
+      }]);
+      const container = Container.edge(docker);
+      await container.bind();
+      expect(container.isRunning()).to.not.be.ok();
+    });
+    it('should return true since the container is running', async function () {
+      listContainers.resolves([{
+        Id: TEST_CONTAINER_ID,
+        State: 'running',
+      }]);
+      const container = Container.edge(docker);
+      await container.bind();
+      expect(container.isRunning()).to.be.ok();
+    });
+  });
+  describe('#hasImage', function () {
+    let listImages;
+    let docker;
+    beforeEach(function () {
+      docker = new Docker();
+      listImages = sinon.stub(docker, 'listImages');
+    });
+    afterEach(function () {
+      listImages.restore();
+      docker = undefined;
+    });
+    it('should return false since cannot find a image locally', async function () {
+      listImages.resolves([]);
+      const container = Container.edge(docker);
+      expect(await container.hasImage()).to.not.be.ok();
+    });
+    it('should return true since find a image locally', async function () {
+      listImages.resolves([{
+        Id: '4f0cf2cf1be12',
+        ParentId: '',
+      }]);
+      const container = Container.edge(docker);
+      expect(await container.hasImage()).to.be.ok();
+    });
+  });
+  describe('#pullImage', function () {
+    let listImages;
+    let docker;
+    beforeEach(function () {
+      docker = new Docker();
+      listImages = sinon.stub(docker, 'pull');
+    });
+    afterEach(function () {
+      listImages.restore();
+      docker = undefined;
+    });
+    it('should fail since connection error', async function () {
+      listImages.rejects(new Error('Cannot connect to the registry'));
+      let error;
+      try {
+        const container = Container.edge(docker);
+        await container.pullImage();
+      } catch (err) {
+        error = err;
+      }
+      expect(error).to.be.an(Error);
+    });
+    it('should fail since download error', async function () {
+      listImages.resolves(process.stdin);
+      const follow = sinon.stub(docker.modem, 'followProgress')
+        .callsFake(function (stream, onFinished, onProgress) {
+          onFinished(new Error('Cannot read data from ' + stream));
+        });
+      let error;
+      try {
+        const container = Container.edge(docker);
+        await container.pullImage();
+      } catch (err) {
+        error = err;
+      }
+      expect(error).to.be.an(Error);
+      follow.restore();
+    });
+    it('should pass since all requirements meet', async function () {
+      listImages.resolves(process.stdin);
+      const follow = sinon.stub(docker.modem, 'followProgress')
+        .callsFake(function (stream, onFinished, onProgress) {
+          onFinished(null);
+        });
+      const container = Container.edge(docker);
+      expect(await container.pullImage()).to.be.ok();
+      follow.restore();
+    });
+  });
+  describe('#create', function () {
+    let key = 'Your Product Key';
+    let name = 'Your Device Name';
+    let secret = 'Your Device Secret';
+    let run;
+    let docker;
+    beforeEach(function () {
+      docker = new Docker();
+      run = sinon.stub(docker, 'run');
+    });
+    afterEach(function () {
+      run.restore();
+      docker = undefined;
+    });
+    it('should fail since the container already exists', async function () {
+      const listContainers = sinon.stub(docker, 'listContainers');
+      listContainers.resolves([{
+        Id: TEST_CONTAINER_ID,
+      }]);
+      let error;
+      try {
+        const container = Container.edge(docker);
+        await container.bind();
+        await container.create();
+      } catch (err) {
+        error = err;
+      }
+      expect(error).to.be.an(Error);
+      listContainers.restore();
+    });
+    it('should fail since read secret triples error', async function () {
+      const prompt = sinon.stub(inquirer, 'prompt').rejects(new Error('Cannot read secret triples'));
+      let error;
+      try {
+        const container = Container.edge(docker);
+        await container.create();
+      } catch (err) {
+        error = err;
+      }
+      expect(error).to.be.an(Error);
+      prompt.restore();
+    });
+    it('should fail since applying secret triples error', async function () {
+      run.rejects(new Error(`Cannot apply secret triples`));
+      const prompt = sinon.stub(inquirer, 'prompt').resolves({ key, name, secret });
+      let error;
+      try {
+        const container = Container.edge(docker);
+        await container.create();
+      } catch (err) {
+        error = err;
+      }
+      expect(error).to.be.an(Error);
+      prompt.restore();
+    });
+    it('should fail since create container error', async function () {
+      run.resolves();
+      const prompt = sinon.stub(inquirer, 'prompt').resolves({ key, name, secret });
+      const createContainer = sinon.stub(docker, 'createContainer')
+        .rejects(new Error('Cannot create the container'));
+      let error;
+      try {
+        const container = Container.edge(docker);
+        await container.create();
+      } catch (err) {
+        error = err;
+      }
+      expect(error).to.be.an(Error);
+      createContainer.restore();
+      prompt.restore();
+    });
+    it('should pass since all requirements meet', async function () {
+      run.resolves();
+      const prompt = sinon.stub(inquirer, 'prompt').resolves({ key, name, secret });
+      const createContainer = sinon.stub(docker, 'createContainer').resolves({
+        id: TEST_CONTAINER_ID
+      });
+      function restore() {
+        createContainer.restore();
+        prompt.restore();
+      }
+      const container = Container.edge(docker);
+      const id = await container.create();
+      expect(id).to.be(TEST_CONTAINER_ID);
+      restore();
+    });
+  });
+  describe('#start', function () {
+    let docker;
+    let container;
+    let hasImage;
+    let pullImage;
+    beforeEach(function () {
+      docker =  Docker();
+      container = Container.edge(docker);
+      hasImage = sinon.stub(container, 'hasImage').resolves(true);
+      pullImage = sinon.stub(container, 'pullImage').resolves();
+    });
+    afterEach(function () {
+      hasImage.restore();
+      pullImage.restore();
+      docker = undefined;
+      container = undefined;
+    });
+    it('should skip creating a container since a local one was created', async function () {
+      const listContainers = sinon.stub(docker, 'listContainers').resolves([{
+        Id: TEST_CONTAINER_ID,
+        State: 'running',
+      }]);
+      const create = sinon.stub(container, 'create').callsFake(function () {
+        return Promise.resolve(TEST_CONTAINER_ID);
+      });
+      await container.start();
+      expect(create.calledOnce).to.not.be.ok;
+      create.restore();
+      listContainers.restore();
+    });
+    it('should create a container since no local one found', async function () {
+      const listContainers = sinon.stub(docker, 'listContainers').resolves([]);
+      const create = sinon.stub(container, 'create').callsFake(function () {
+        return Promise.resolve(TEST_CONTAINER_ID);
+      });
+      const getContainer = sinon.stub(docker, 'getContainer').returns({
+        start: async function () {},
+      });
+      await container.start();
+      expect(create.calledOnce).to.be.ok;
+      getContainer.restore();
+      create.restore();
+      listContainers.restore();
+    });
+    it('should skip starting the container since it is running', async function () {
+      const listContainers = sinon.stub(docker, 'listContainers').resolves([{
+        Id: TEST_CONTAINER_ID,
+        State: 'running',
+      }]);
+      const spy = sinon.spy();
+      const getContainer = sinon.stub(docker, 'getContainer').returns({
+        start: async function () {
+          spy();
+        },
+      });
+      await container.start();
+      expect(spy.calledOnce).to.not.be.ok;
+      getContainer.restore();
+      listContainers.restore();
+    });
+    it('should start the container since it is not running', async function () {
+      const listContainers = sinon.stub(docker, 'listContainers').resolves([{
+        Id: TEST_CONTAINER_ID,
+      }]);
+      const spy = sinon.spy();
+      const getContainer = sinon.stub(docker, 'getContainer').returns({
+        start: async function () {
+          spy();
+        },
+      });
+      await container.start();
+      expect(spy.calledOnce).to.be.ok;
+      getContainer.restore();
+      listContainers.restore();
+    });
+  });
+  describe('#stop', function () {
+    let docker;
+    beforeEach(function () {
+      docker =  Docker();
+    });
+    afterEach(function () {
+      docker = undefined;
+    });
+    it('should skip stopping since the local container is not created', async function () {
+      const listContainers = sinon.stub(docker, 'listContainers').resolves([]);
+      const getContainer = sinon.stub(docker, 'getContainer').returns({});
+      const container = Container.edge(docker);
+      await container.stop();
+      expect(getContainer.calledOnce).to.not.be.ok;
+      getContainer.restore();
+      listContainers.restore();
+    });
+    it('should skip stopping since the local container is not running', async function () {
+      const listContainers = sinon.stub(docker, 'listContainers').resolves([{
+        Id: TEST_CONTAINER_ID,
+        State: 'exited'
+      }]);
+      const getContainer = sinon.stub(docker, 'getContainer').returns({});
+      const container = Container.edge(docker);
+      await container.stop();
+      expect(getContainer.calledOnce).to.not.be.ok;
+      getContainer.restore();
+      listContainers.restore();
+    });
+    it('should stop the container since it is running', async function () {
+      const listContainers = sinon.stub(docker, 'listContainers').resolves([{
+        Id: TEST_CONTAINER_ID,
+        State: 'running'
+      }]);
+      const spy = sinon.spy();
+      const getContainer = sinon.stub(docker, 'getContainer').returns({
+        stop: async function () {
+          spy();
+        }
+      });
+      const container = Container.edge(docker);
+      await container.stop();
+      expect(spy.calledOnce).to.be.ok;
+      getContainer.restore();
+      listContainers.restore();
+    });
+  });
+  describe('#copy', function () {
+    let docker;
+    beforeEach(function () {
+      docker = Docker();
+    });
+    afterEach(function () {
+      docker = undefined;
+    });
+    it('should throw since the local container is not created', async function () {
+      const listContainers = sinon.stub(docker, 'listContainers').resolves([]);
+      const container = Container.edge(docker);
+      let error;
+      try {
+        await container.copy(TEST_COPY_SOURCE_TAR, TEST_COPY_TARGET_DIR);
+      } catch (err) {
+        error = err;
+      }
+      expect(error).to.be.an(Error);
+      listContainers.restore();
+    });
+    it('should throw since the local container is not running', async function () {
+      const listContainers = sinon.stub(docker, 'listContainers').resolves([{
+        Id: TEST_CONTAINER_ID,
+        State: 'exited',
+      }]);
+      const container = Container.edge(docker);
+      let error;
+      try {
+        await container.copy(TEST_COPY_SOURCE_TAR, TEST_COPY_TARGET_DIR);
+      } catch (err) {
+        error = err;
+      }
+      expect(error).to.be.an(Error);
+      listContainers.restore();
+    });
+    it('should pass since all requirements meet', async function () {
+      const listContainers = sinon.stub(docker, 'listContainers').resolves([{
+        Id: TEST_CONTAINER_ID,
+        State: 'running',
+      }]);
+      const getContainer = sinon.stub(docker, 'getContainer').returns({
+        exec: async function () {
+          return {
+            start: async function () {
+              return {
+                output: {
+                  on: function (event, handler) {
+                    if (event === 'end') {
+                      handler();
+                    }
+                  }
+                },
+              };
+            }
+          };
+        },
+        putArchive: async function () {
+          return true;
+        }
+      });
+      const container = Container.edge(docker);
+      let error;
+      try {
+        await container.copy(TEST_COPY_SOURCE_TAR, TEST_COPY_TARGET_DIR);
+      } catch (err) {
+        error = err;
+      }
+      expect(error).to.not.be.an(Error);
+      getContainer.restore();
+      listContainers.restore();
+    });
+  });
+});

--- a/test/edge/runner.test.js
+++ b/test/edge/runner.test.js
@@ -1,0 +1,67 @@
+'use strict';
+
+const expect = require('expect.js');
+const sinon = require('sinon');
+
+describe('edge/Runner', function () {
+  const LocalRuntime = require('../../lib/edge/runtime');
+  const definition = require('../../lib/definition');
+  const template = {
+    Properties: {
+      Handler: 'index.handler',
+      Runtime: 'nodejs8',
+      CodeUri: './',
+      Timeout: 60,
+    },
+  };
+  let findFunction;
+  let LocalRunner;
+  before(function () {
+    findFunction = sinon.stub(definition, 'findFunctionInTpl').returns({
+      functionRes: template,
+    });
+    LocalRunner = require('../../lib/edge/runner');
+  });
+  after(function () {
+    findFunction.restore();
+  });
+
+  describe('#invoke', function () {
+    const runtime = new LocalRuntime();
+    const options = {
+      cwd: __dirname,
+      runtime,
+      template,
+      profile: {
+        region: 'cn-hangzhou',
+        accountId: 'account_id',
+      },
+      debugInfo: {
+        debugPort: 5700,
+        outputDebuggerConfigs: true,
+      },
+    };
+    const identifier = {
+      serviceName: 'service_name',
+      functionName: 'function_name',
+    };
+    let runtimeInvoke;
+    beforeEach(function () {
+      runtimeInvoke = sinon.stub(runtime, 'invoke');
+    });
+    afterEach(function () {
+      runtimeInvoke.restore();
+    });
+    it('should throw since runtime invoking error', async function () {
+      runtimeInvoke.rejects(new Error('Cannot invoke'));
+      const runner = new LocalRunner(options);
+      let error;
+      try {
+        await runner.invoke(identifier, {});
+      } catch (err) {
+        error = err;
+      }
+      expect(error).to.be.an(Error);
+    });
+  });
+});

--- a/test/edge/runtime.test.js
+++ b/test/edge/runtime.test.js
@@ -3,7 +3,6 @@
 const expect = require('expect.js');
 const sinon = require('sinon');
 const path = require('path');
-const util = require('util');
 
 const LocalRuntime = require('../../lib/edge/runtime');
 

--- a/test/edge/runtime.test.js
+++ b/test/edge/runtime.test.js
@@ -1,0 +1,135 @@
+'use strict';
+
+const expect = require('expect.js');
+const sinon = require('sinon');
+const path = require('path');
+const util = require('util');
+
+const LocalRuntime = require('../../lib/edge/runtime');
+
+describe('edge/LocalRuntime', function () {
+  describe('#invoke', function () {
+    let config;
+    beforeEach(function () {
+      config = {
+        runtime: 'nodejs8',
+        identifier: {
+          region: 'ch-hangzhou',
+          accountId: 'account_id',
+          serviceName: 'service_name',
+          functionName: 'function_name',
+        },
+        handler: 'index.handler',
+        timeout: 3,
+        memory: 128,
+        codeAbsPath: path.resolve(__dirname, '../../examples/helloworld/helloworld.js'),
+      };
+    });
+
+    afterEach(function () {
+      config = undefined;
+    });
+    it('should fail since unsupported runtime', async function () {
+      config.runtime = 'java8';
+      const runtime = new LocalRuntime();
+      let error;
+      try {
+        await runtime.invoke(config, {});
+      } catch (err) {
+        error = err;
+      }
+      expect(error).to.be.an(Error);
+    });
+    it('should fail since copying code to container fails', async function () {
+      const runtime = new LocalRuntime();
+      const stub = sinon.stub(runtime.container, 'copy').rejects(new Error('Cannot copy'));
+      let error;
+      try {
+        await runtime.invoke(config, {});
+      } catch (err) {
+        error = err;
+      }
+      expect(error).to.be.an(Error);
+      stub.restore();
+    });
+    it('should fail since deploying function fails', async function () {
+      const runtime = new LocalRuntime();
+      const copy = sinon.stub(runtime.container, 'copy').resolves();
+      const deploy = sinon.stub(runtime.client, 'deploy').rejects(new Error('Cannot deploy'));
+      let error;
+      try {
+        await runtime.invoke(config, {});
+      } catch (err) {
+        error = err;
+      }
+      expect(error).to.be.an(Error);
+      deploy.restore();
+      copy.restore();
+    });
+    it('should fail since invoking function fails', async function () {
+      const runtime = new LocalRuntime();
+      const copy = sinon.stub(runtime.container, 'copy').resolves();
+      const deploy = sinon.stub(runtime.client, 'deploy').resolves();
+      const invoke = sinon.stub(runtime.client, 'invoke').rejects(new Error('Cannot invoke'));
+      let error;
+      try {
+        await runtime.invoke(config, {});
+      } catch (err) {
+        error = err;
+      }
+      expect(error).to.be.an(Error);
+      invoke.restore();
+      deploy.restore();
+      copy.restore();
+    });
+    it('should pass since all requirements meet', async function () {
+      const runtime = new LocalRuntime();
+      const copy = sinon.stub(runtime.container, 'copy').resolves();
+      const deploy = sinon.stub(runtime.client, 'deploy').resolves();
+      const invoke = sinon.stub(runtime.client, 'invoke').resolves(Buffer.from(''));
+      let error;
+      try {
+        await runtime.invoke(config, {});
+      } catch (err) {
+        error = err;
+      }
+      expect(error).to.be(undefined);
+      invoke.restore();
+      deploy.restore();
+      copy.restore();
+    });
+    it('should output debugger configs since output-debugger-configs is set', async function () {
+      const runtime = new LocalRuntime();
+      const copy = sinon.stub(runtime.container, 'copy').resolves();
+      const deploy = sinon.stub(runtime.client, 'deploy').resolves();
+      const invoke = sinon.stub(runtime.client, 'invoke').resolves(Buffer.from(''));
+      const spy = sinon.spy(console, 'log');
+      await runtime.invoke(config, {}, {
+        debugPort: 5700,
+        outputDebuggerConfigs: true,
+      });
+      expect(spy.calledWith(sinon.match('Attach to Fun (Node.js 8)')));
+      spy.restore();
+      invoke.restore();
+      deploy.restore();
+      copy.restore();
+    });
+    it('should output python debugger configs since runtime is python3', async function () {
+      config.runtime = 'python3';
+      const runtime = new LocalRuntime();
+      const copy = sinon.stub(runtime.container, 'copy').resolves();
+      const deploy = sinon.stub(runtime.client, 'deploy').resolves();
+      const invoke = sinon.stub(runtime.client, 'invoke').resolves(Buffer.from(''));
+      const spy = sinon.spy(console, 'log');
+      await runtime.invoke(config, {}, {
+        debugPort: 5700,
+        outputDebuggerConfigs: true,
+      });
+      expect(spy.calledWith(sinon.match('Attach to Fun (Python 3)')));
+      spy.restore();
+      invoke.restore();
+      deploy.restore();
+      copy.restore();
+    });
+  });
+});


### PR DESCRIPTION
When running on Windows, we cannot receive the 'end' event on the socket returned from `exec.start()` API of `dockerode`. Just send the 'end' event manually to work around it.

It's a common case, and we will fix it in the next version.