### PR TITLE
Work around edge invoke hanging on Windows

### DIFF
--- a/lib/edge/container.js
+++ b/lib/edge/container.js
@@ -197,13 +197,18 @@ class Container {
       AttachStderr: true,
       Tty: true,
     });
-    const stream = await exec.start({hijack: true});
     await new Promise((resolve, reject) => {
-      stream.output.on('end', () => {
-        resolve();
-      });
-      stream.output.on('error', (err) => {
-        reject(err);
+      exec.start({hijack: true}, (err, stream) => {
+        stream.on('end', () => {
+          resolve();
+        });
+        stream.on('error', (err) => {
+          reject(err);
+        });
+        // FIXME There is no 'end' event being received on windows. Send one manually.
+        if (process.platform === 'win32') {
+          setTimeout(() => stream.end(), 0);
+        }
       });
     });
     // Copy to the target path.

--- a/test/edge/container.test.js
+++ b/test/edge/container.test.js
@@ -4,6 +4,7 @@ const expect = require('expect.js');
 const sinon = require('sinon');
 const Docker = require('dockerode');
 const inquirer = require('inquirer');
+const EventEmitter = require('events');
 const Container = require('../../lib/edge/container');
 
 const TEST_CONTAINER_ID = 'd852359721fe';
@@ -394,16 +395,15 @@ describe('edge/Container', function () {
       const getContainer = sinon.stub(docker, 'getContainer').returns({
         exec: async function () {
           return {
-            start: async function () {
-              return {
-                output: {
-                  on: function (event, handler) {
-                    if (event === 'end') {
-                      handler();
-                    }
-                  }
-                },
-              };
+            start: function (opts, callback) {
+              class Stream extends EventEmitter {
+                end() {
+                  this.emit('end');
+                }
+              }
+              const stream = new Stream();
+              setTimeout(() => stream.end(), 0);
+              callback(null, stream);
             }
           };
         },


### PR DESCRIPTION
When running on Windows, we cannot receive the 'end' event on the socket returned from`exec.start()` API of `dockerode`. Just send the 'end' event manually to work around it.

It's a common case, and we will fix it in the next version.