### PR TITLE
sunfeiyu/soft_link_problem_when_fun_install

### DIFF
--- a/lib/docker-opts.js
+++ b/lib/docker-opts.js
@@ -30,9 +30,9 @@ function resolveRuntimeToDockerImage(runtime, isBuild) {
     const name = runtimeImageMap[runtime];
     var imageName;
     if (isBuild) {
-      imageName = `aliyunfc/runtime-${name}:build-1.5.3`;
+      imageName = `aliyunfc/runtime-${name}:build-1.5.4`;
     } else {
-      imageName = `aliyunfc/runtime-${name}:1.5.3`;
+      imageName = `aliyunfc/runtime-${name}:1.5.4`;
     }
 
     debug('imageName: ' + imageName);

--- a/lib/docker-opts.js
+++ b/lib/docker-opts.js
@@ -30,9 +30,9 @@ function resolveRuntimeToDockerImage(runtime, isBuild) {
     const name = runtimeImageMap[runtime];
     var imageName;
     if (isBuild) {
-      imageName = `aliyunfc/runtime-${name}:build-1.5.4`;
+      imageName = `aliyunfc/runtime-${name}:build-1.5.5`;
     } else {
-      imageName = `aliyunfc/runtime-${name}:1.5.4`;
+      imageName = `aliyunfc/runtime-${name}:1.5.5`;
     }
 
     debug('imageName: ' + imageName);

--- a/lib/install/task.js
+++ b/lib/install/task.js
@@ -115,8 +115,16 @@ class AptTask extends InstallTask {
 
   async instDeb() {
     const instDir = '/code/.fun/root';
-    console.log(green('     => ') + cyan('bash -c \'for f in $(ls %s/archives/*.deb); do dpkg -x $f %s; done;\''), this.cacheDir, instDir);
-    await this._exec(['bash', '-c', `for f in $(ls ${this.cacheDir}/archives/*.deb); do dpkg -x $f ${instDir} ; done;`]);
+    console.log(green('     => ') + cyan(`bash -c 
+        for f in $(ls %s/archives/*.deb); do
+          dpkg -x $f %s; mkdir -p %s/deb-control/\${f%.*}; 
+          dpkg -e $f %s/deb-control/\${f%.*}; 
+
+          if [ -f "%s/deb-control/\${f%.*}/postinst" ]; then 
+            FUN_INSTALL_LOCAL=true %s/deb-control/\${f%.*}/postinst configure;
+          fi; 
+        done;`), this.cacheDir, instDir, this.cacheDir, this.cacheDir, this.cacheDir, this.cacheDir);
+    await this._exec(['bash', '-c', `for f in $(ls ${this.cacheDir}/archives/*.deb); do dpkg -x $f ${instDir}; mkdir -p ${this.cacheDir}/deb-control/\${f%.*}; dpkg -e $f ${this.cacheDir}/deb-control/\${f%.*}; if [ -f "${this.cacheDir}/deb-control/\${f%.*}/postinst" ]; then FUN_INSTALL_LOCAL=true ${this.cacheDir}/deb-control/\${f%.*}/postinst configure; fi; done;`]);  
   }
 
   async cleanup() {

--- a/test/docker-opts.test.js
+++ b/test/docker-opts.test.js
@@ -71,7 +71,7 @@ describe('test generateLocalInvokeOpts', () => {
       'OpenStdin': true,
       'StdinOnce': true,
       'Tty': false,
-      'Image': 'aliyunfc/runtime-nodejs8:1.5.4',
+      'Image': 'aliyunfc/runtime-nodejs8:1.5.5',
       'HostConfig': {
         'AutoRemove': true,
         'Mounts': [
@@ -115,7 +115,7 @@ describe('test generateLocalInvokeOpts', () => {
       'StdinOnce': true,
       'Tty': false,
       'User': null,
-      'Image': 'aliyunfc/runtime-nodejs8:1.5.4',
+      'Image': 'aliyunfc/runtime-nodejs8:1.5.5',
       'Env': [
         'LD_LIBRARY_PATH=/code/.fun/root/usr/lib:/code/.fun/root/usr/lib/x86_64-linux-gnu:/code:/code/lib:/usr/local/lib',
         'PATH=/code/.fun/root/usr/local/bin:/code/.fun/root/usr/local/sbin:/code/.fun/root/usr/bin:/code/.fun/root/usr/sbin:/code/.fun/root/sbin:/code/.fun/root/bin:/code/.fun/python/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/sbin:/bin',

--- a/test/docker-opts.test.js
+++ b/test/docker-opts.test.js
@@ -71,7 +71,7 @@ describe('test generateLocalInvokeOpts', () => {
       'OpenStdin': true,
       'StdinOnce': true,
       'Tty': false,
-      'Image': 'aliyunfc/runtime-nodejs8:1.5.3',
+      'Image': 'aliyunfc/runtime-nodejs8:1.5.4',
       'HostConfig': {
         'AutoRemove': true,
         'Mounts': [
@@ -115,7 +115,7 @@ describe('test generateLocalInvokeOpts', () => {
       'StdinOnce': true,
       'Tty': false,
       'User': null,
-      'Image': 'aliyunfc/runtime-nodejs8:1.5.3',
+      'Image': 'aliyunfc/runtime-nodejs8:1.5.4',
       'Env': [
         'LD_LIBRARY_PATH=/code/.fun/root/usr/lib:/code/.fun/root/usr/lib/x86_64-linux-gnu:/code:/code/lib:/usr/local/lib',
         'PATH=/code/.fun/root/usr/local/bin:/code/.fun/root/usr/local/sbin:/code/.fun/root/usr/bin:/code/.fun/root/usr/sbin:/code/.fun/root/sbin:/code/.fun/root/bin:/code/.fun/python/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/sbin:/bin',

--- a/test/local/invoke.test.js
+++ b/test/local/invoke.test.js
@@ -77,9 +77,9 @@ describe('test invoke construct and init', async () => {
     expect(invoke.codeMount).to.eql(codeMount);
     expect(invoke.mounts).to.eql([codeMount]);
     expect(invoke.containerName).to.contain('fun_local_');
-    expect(invoke.imageName).to.contain('aliyunfc/runtime-python3.6:1.5.4');
+    expect(invoke.imageName).to.contain('aliyunfc/runtime-python3.6:1.5.5');
 
-    assert.calledWith(docker.pullImageIfNeed, 'aliyunfc/runtime-python3.6:1.5.4');
+    assert.calledWith(docker.pullImageIfNeed, 'aliyunfc/runtime-python3.6:1.5.5');
   });
 
   it('test init with nas config', async () => {
@@ -109,9 +109,9 @@ describe('test invoke construct and init', async () => {
     expect(invoke.codeMount).to.eql(codeMount);
     expect(invoke.mounts).to.eql([codeMount, ...nasMounts]);
     expect(invoke.containerName).to.contain('fun_local_');
-    expect(invoke.imageName).to.eql('aliyunfc/runtime-python3.6:1.5.4');
+    expect(invoke.imageName).to.eql('aliyunfc/runtime-python3.6:1.5.5');
 
-    assert.calledWith(docker.pullImageIfNeed, 'aliyunfc/runtime-python3.6:1.5.4');
+    assert.calledWith(docker.pullImageIfNeed, 'aliyunfc/runtime-python3.6:1.5.5');
   });
 });
 

--- a/test/local/invoke.test.js
+++ b/test/local/invoke.test.js
@@ -77,9 +77,9 @@ describe('test invoke construct and init', async () => {
     expect(invoke.codeMount).to.eql(codeMount);
     expect(invoke.mounts).to.eql([codeMount]);
     expect(invoke.containerName).to.contain('fun_local_');
-    expect(invoke.imageName).to.contain('aliyunfc/runtime-python3.6:1.5.3');
+    expect(invoke.imageName).to.contain('aliyunfc/runtime-python3.6:1.5.4');
 
-    assert.calledWith(docker.pullImageIfNeed, 'aliyunfc/runtime-python3.6:1.5.3');
+    assert.calledWith(docker.pullImageIfNeed, 'aliyunfc/runtime-python3.6:1.5.4');
   });
 
   it('test init with nas config', async () => {
@@ -109,9 +109,9 @@ describe('test invoke construct and init', async () => {
     expect(invoke.codeMount).to.eql(codeMount);
     expect(invoke.mounts).to.eql([codeMount, ...nasMounts]);
     expect(invoke.containerName).to.contain('fun_local_');
-    expect(invoke.imageName).to.eql('aliyunfc/runtime-python3.6:1.5.3');
+    expect(invoke.imageName).to.eql('aliyunfc/runtime-python3.6:1.5.4');
 
-    assert.calledWith(docker.pullImageIfNeed, 'aliyunfc/runtime-python3.6:1.5.3');
+    assert.calledWith(docker.pullImageIfNeed, 'aliyunfc/runtime-python3.6:1.5.4');
   });
 });
 


### PR DESCRIPTION
用户反应某些 deb 包通过 fun install 安装后无法正确的生成可执行文件的软链接，需要通过 shell 命令创建软链接或者改文件名，否则会导致可执行文件找不到的问题。已知有问题的 deb 包有：traceroute 和 netcat-traditional 